### PR TITLE
Resolve issues regarding Nokee nightly release 0.4

### DIFF
--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -36,12 +36,12 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: auto-dark-mode-windows_x86.dll
-          path: windows/build/libs/main/shared/windowsx86/auto-dark-mode-windows.dll
+          path: windows/build/libs/main/x86/auto-dark-mode-windows.dll
       - name: Upload x86-64 artifact
         uses: actions/upload-artifact@v1
         with:
           name: auto-dark-mode-windows_x86-64.dll
-          path: windows/build/libs/main/shared/windowsx86-64/auto-dark-mode-windows.dll
+          path: windows/build/libs/main/x86-64/auto-dark-mode-windows.dll
 
   macOS:
     name: macOS (Java 11)

--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -68,9 +68,9 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: libauto-dark-mode-macos.dylib
-          path: macos/build/libs/main/shared/libauto-dark-mode-macos.dylib
+          path: macos/build/libs/main/libauto-dark-mode-macos.dylib
       - name: Print library information
-        run: otool -l macos/build/libs/main/shared/libauto-dark-mode-macos.dylib
+        run: otool -l macos/build/libs/main/libauto-dark-mode-macos.dylib
       - name: Upload build log
         if: always()
         uses: actions/upload-artifact@v1

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("dev.nokee:nokee-gradle-plugins:0.4.0-92d0755"))
+    implementation(platform("dev.nokee:nokee-gradle-plugins:0.4.0-80d5445"))
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation("dev.nokee:platformJni:0.4.0-28912e7")
+    implementation(platform("dev.nokee:nokee-gradle-plugins:0.4.0-22683ef"))
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation("dev.nokee:platformJni:0.3.0-df4e5ab")
+    implementation("dev.nokee:platformJni:0.4.0-28912e7")
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("dev.nokee:nokee-gradle-plugins:0.4.0-727859f"))
+    implementation(platform("dev.nokee:nokee-gradle-plugins:0.4.0-92d0755"))
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("dev.nokee:nokee-gradle-plugins:0.4.0-22683ef"))
+    implementation(platform("dev.nokee:nokee-gradle-plugins:0.4.0-727859f"))
 }
 
 repositories {
@@ -19,6 +19,10 @@ gradlePlugin {
         create("uber-jni-jar") {
             id = "uber-jni-jar"
             implementationClass = "UberJniJarPlugin"
+        }
+        create("use-prebuilt-binaries") {
+            id = "use-prebuilt-binaries"
+            implementationClass = "UsePrebuiltBinariesWhenUnbuildablePlugin"
         }
     }
 }

--- a/buildSrc/src/main/groovy/JniUtils.groovy
+++ b/buildSrc/src/main/groovy/JniUtils.groovy
@@ -1,0 +1,17 @@
+import dev.nokee.platform.nativebase.TargetMachine
+
+class JniUtils {
+    static String asVariantName(TargetMachine targetMachine) {
+        String operatingSystemFamily = 'macos'
+        if (targetMachine.operatingSystemFamily.windows) {
+            operatingSystemFamily = 'windows'
+        }
+
+        String architecture = 'x86-64'
+        if (targetMachine.architecture.'32Bit') {
+            architecture = 'x86'
+        }
+
+        return "$operatingSystemFamily-$architecture"
+    }
+}

--- a/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
+++ b/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
@@ -40,7 +40,7 @@ class UberJniJarPlugin implements Plugin<Project> {
         task.from(variants.map(jniLibraryBinaryFiles(project)))
     }
 
-    private static Closure<List<FileTree>> jniLibraryBinaryFiles(Project project) {
+    private static Closure<List<Provider<FileTree>>> jniLibraryBinaryFiles(Project project) {
         return { List<? extends JniLibrary> variants ->
             // Single variant are collapse into the JVM Jar
             if (variants.size() > 1) {
@@ -49,13 +49,13 @@ class UberJniJarPlugin implements Plugin<Project> {
                     variant.binaries.withType(JniJarBinary).elements.get().each { jniJarBinaries << it }
                 }
 
-                List<FileTree> result = []
-                for (Provider<RegularFile> archiveFile : jniJarBinaries*.jarTask*.get()*.archiveFile) {
-                    result << project.zipTree(archiveFile).matching { PatternFilterable p -> p.exclude('META-INF/**/*') }
+                List<Provider<FileTree>> result = []
+                for (Provider<Jar> jarTask : jniJarBinaries*.jarTask) {
+                    result << jarTask.map { project.zipTree(it.archiveFile).matching { PatternFilterable p -> p.exclude('META-INF/**/*') } }
                 }
                 return result
             }
-            return [] as List<FileTree>
+            return [] as List<Provider<FileTree>>
         }
     }
 

--- a/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
+++ b/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
@@ -1,17 +1,12 @@
-import dev.nokee.platform.jni.JniJarBinary
 import dev.nokee.platform.jni.JniLibrary
 import dev.nokee.platform.jni.JniLibraryExtension
-import dev.nokee.platform.nativebase.TargetMachine
+import dev.nokee.runtime.nativebase.TargetMachine
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Transformer
 import org.gradle.api.file.CopySpec
-import org.gradle.api.file.FileTree
-import org.gradle.api.file.RegularFile
-import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.jvm.tasks.Jar
 
 @CompileStatic
@@ -27,112 +22,37 @@ class UberJniJarPlugin implements Plugin<Project> {
         def project = task.getProject()
         def logger = task.getLogger()
         def library = project.extensions.getByType(JniLibraryExtension)
-        def buildableVariants = library.variants.flatMap(onlyBuildableVariant())
-        includeBuiltJniJarContent(logger, project, task, library, buildableVariants);
-
-        def unbuildableVariants = library.variants.flatMap(onlyUnbuildableVariant())
-        usePrebuiltBinaryIfAvailable(project, library, logger, task, unbuildableVariants);
-    }
-
-    private static void includeBuiltJniJarContent(Logger logger, Project project, Jar task, JniLibraryExtension library, Provider<List<? extends JniLibrary>> variants) {
-        logger.info("${project.name}: Merging binaries into the JVM Jar.")
-        // There is no need to specify the destination of the content as it's already configured via library.resourcePath property
-        task.from(variants.map(jniLibraryBinaryFiles(project)))
-    }
-
-    private static Closure<List<Provider<FileTree>>> jniLibraryBinaryFiles(Project project) {
-        return { List<? extends JniLibrary> variants ->
-            // Single variant are collapse into the JVM Jar
-            if (variants.size() > 1) {
-                List<JniJarBinary> jniJarBinaries = []
-                for (JniLibrary variant : variants) {
-                    variant.binaries.withType(JniJarBinary).elements.get().each { jniJarBinaries << it }
-                }
-
-                List<Provider<FileTree>> result = []
-                for (Provider<Jar> jarTask : jniJarBinaries*.jarTask) {
-                    result << jarTask.map { project.zipTree(it.archiveFile).matching { PatternFilterable p -> p.exclude('META-INF/**/*') } }
-                }
-                return result
-            }
-            return [] as List<Provider<FileTree>>
-        }
-    }
-
-    private static void usePrebuiltBinaryIfAvailable(Project project, JniLibraryExtension library, Logger logger, Jar task, Provider<List<? extends JniLibrary>> variants) {
-        for (TargetMachine targetMachine : library.targetMachines.get()) {
-            def libraryPath = "com/github/weisj/darkmode/${project.name}"
-            def variantName = asVariantName(targetMachine)
-            task.into("$libraryPath/$variantName") { CopySpec spec ->
-                spec.from(variants.map(includeIfUnbuildable(project, logger, targetMachine)))
-            }
-        }
-    }
-
-    private static Closure<List<File>> includeIfUnbuildable(Project project, Logger logger, TargetMachine targetMachine) {
-        boolean messageAlreadyLogged = false
-        return { List<JniLibrary> variants ->
-            // Check the unbuildable variant list for a matching target machine
-            if (variants.find {it.targetMachine == targetMachine} != null) {
-                // Try to include the library file... if available
-                def downloadUrl = 'https://github.com/weisJ/auto-dark-mode/actions?query=workflow%3A%22Build+Native+Libraries%22'
-                def defaultLibraryName = project.property('defaultLibraryName')
-                def variantName = asVariantName(targetMachine)
-                def libraryFile = project.file("libraries/$variantName/$defaultLibraryName")
-                def relativePath = project.rootProject.relativePath(libraryFile)
-                if (!messageAlreadyLogged) {
-                    if (!libraryFile.exists()) {
-                        logger.warn("""${project.name}: Library $relativePath for targetMachine $variantName does not exist.
-                            |${" ".multiply(project.name.size() + 1)} Download it from $downloadUrl
-                            |""".stripMargin())
-                    } else {
-                        //Use provided library.
-                        logger.warn("${project.name}: Using pre-build library $relativePath for targetMachine $variantName.")
-                    }
-                    messageAlreadyLogged = true
-                }
-                if (libraryFile.exists()) {
-                    return [libraryFile]
+        if (library.targetMachines.get().size() > 1) {
+            logger.info("${project.name}: Merging binaries into the JVM Jar.")
+            for (TargetMachine targetMachine : library.targetMachines.get()) {
+                Provider<JniLibrary> variant = library.variants.flatMap(targetMachineOf(targetMachine)).map(onlyOne())
+                task.into(variant.map { it.resourcePath }) { CopySpec spec ->
+                    spec.from(variant.map { it.nativeRuntimeFiles })
                 }
             }
-            return [] as List<File>
         }
     }
 
-    static String asVariantName(TargetMachine targetMachine) {
-        String operatingSystemFamily = 'macos'
-        if (targetMachine.operatingSystemFamily.windows) {
-            operatingSystemFamily = 'windows'
-        }
-
-        String architecture = 'x86-64'
-        if (targetMachine.architecture.'32Bit') {
-            architecture = 'x86'
-        }
-
-        return "$operatingSystemFamily-$architecture"
-    }
-
-    static Transformer<Iterable<JniLibrary>, JniLibrary> onlyBuildableVariant() {
+    // Filter variants that match the specified target machine.
+    private static Transformer<Iterable<JniLibrary>, JniLibrary> targetMachineOf(TargetMachine targetMachine) {
         return new Transformer<Iterable<JniLibrary>, JniLibrary>() {
             @Override
-            List<JniLibrary> transform(JniLibrary it) {
-                if (it.sharedLibrary.buildable) {
-                    return [it]
+            Iterable<JniLibrary> transform(JniLibrary variant) {
+                if (variant.targetMachine == targetMachine) {
+                    return [variant]
                 }
                 return []
             }
         }
     }
 
-    static Transformer<Iterable<JniLibrary>, JniLibrary> onlyUnbuildableVariant() {
-        return new Transformer<Iterable<JniLibrary>, JniLibrary>() {
+    // Ensure only a single variant is present in the collection and return the variant.
+    private static Transformer<JniLibrary, List<? extends JniLibrary>> onlyOne() {
+        return new Transformer<JniLibrary, List<? extends JniLibrary>>() {
             @Override
-            List<JniLibrary> transform(JniLibrary it) {
-                if (!it.sharedLibrary.buildable) {
-                    return [it]
-                }
-                return []
+            JniLibrary transform(List<? extends JniLibrary> variants) {
+                assert variants.size() == 1
+                return variants.first()
             }
         }
     }

--- a/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
+++ b/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
@@ -1,12 +1,16 @@
 import dev.nokee.platform.jni.JniJarBinary
+import dev.nokee.platform.jni.JniLibrary
 import dev.nokee.platform.jni.JniLibraryExtension
 import dev.nokee.platform.nativebase.TargetMachine
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Transformer
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileTree
+import org.gradle.api.file.RegularFile
 import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.jvm.tasks.Jar
 
@@ -23,47 +27,75 @@ class UberJniJarPlugin implements Plugin<Project> {
         def project = task.getProject()
         def logger = task.getLogger()
         def library = project.extensions.getByType(JniLibraryExtension)
-        def buildableVariants = library.variants.elements.get()
-        if (buildableVariants.empty) {
-            usePrebuiltBinaryIfAvailable(project, library, logger, task)
-        } else if (buildableVariants.size() > 1) {
-            includeBuiltJniJarContent(logger, project, task, library)
-        }
+        def buildableVariants = library.variants.flatMap(onlyBuildableVariant())
+        includeBuiltJniJarContent(logger, project, task, library, buildableVariants);
+
+        def unbuildableVariants = library.variants.flatMap(onlyUnbuildableVariant())
+        usePrebuiltBinaryIfAvailable(project, library, logger, task, unbuildableVariants);
     }
 
-    private static void includeBuiltJniJarContent(Logger logger, Project project, Jar task, JniLibraryExtension library) {
+    private static void includeBuiltJniJarContent(Logger logger, Project project, Jar task, JniLibraryExtension library, Provider<List<? extends JniLibrary>> variants) {
         logger.info("${project.name}: Merging binaries into the JVM Jar.")
         // There is no need to specify the destination of the content as it's already configured via library.resourcePath property
-        task.from(library.binaries.withType(JniJarBinary).elements.map { Set<JniJarBinary> binaries ->
-            binaries*.jarTask*.map(jniLibraryBinaryFiles(project))
-        })
+        task.from(variants.map(jniLibraryBinaryFiles(project)))
     }
 
-    private static Closure<FileTree> jniLibraryBinaryFiles(Project project) {
-        return { Jar task ->
-            project.zipTree(task.archiveFile).matching { PatternFilterable p -> p.exclude('META-INF/**/*') }
+    private static Closure<List<FileTree>> jniLibraryBinaryFiles(Project project) {
+        return { List<? extends JniLibrary> variants ->
+            // Single variant are collapse into the JVM Jar
+            if (variants.size() > 1) {
+                List<JniJarBinary> jniJarBinaries = []
+                for (JniLibrary variant : variants) {
+                    variant.binaries.withType(JniJarBinary).elements.get().each { jniJarBinaries << it }
+                }
+
+                List<FileTree> result = []
+                for (Provider<RegularFile> archiveFile : jniJarBinaries*.jarTask*.get()*.archiveFile) {
+                    result << project.zipTree(archiveFile).matching { PatternFilterable p -> p.exclude('META-INF/**/*') }
+                }
+                return result
+            }
+            return [] as List<FileTree>
         }
     }
 
-    private static void usePrebuiltBinaryIfAvailable(Project project, JniLibraryExtension library, Logger logger, Jar task) {
-        def downloadUrl = 'https://github.com/weisJ/auto-dark-mode/actions?query=workflow%3A%22Build+Native+Libraries%22'
-        def defaultLibraryName = project.property('defaultLibraryName')
+    private static void usePrebuiltBinaryIfAvailable(Project project, JniLibraryExtension library, Logger logger, Jar task, Provider<List<? extends JniLibrary>> variants) {
         for (TargetMachine targetMachine : library.targetMachines.get()) {
             def libraryPath = "com/github/weisj/darkmode/${project.name}"
             def variantName = asVariantName(targetMachine)
-            def libraryFile = project.file("libraries/$variantName/$defaultLibraryName")
-            def relativePath = project.rootProject.relativePath(libraryFile)
-            if (!libraryFile.exists()) {
-                logger.warn("""${project.name}: Library $relativePath for targetMachine $variantName does not exist.
+            task.into("$libraryPath/$variantName") { CopySpec spec ->
+                spec.from(variants.map(includeIfUnbuildable(project, logger, targetMachine)))
+            }
+        }
+    }
+
+    private static Closure<List<File>> includeIfUnbuildable(Project project, Logger logger, TargetMachine targetMachine) {
+        boolean messageAlreadyLogged = false
+        return { List<JniLibrary> variants ->
+            // Check the unbuildable variant list for a matching target machine
+            if (variants.find {it.targetMachine == targetMachine} != null) {
+                // Try to include the library file... if available
+                def downloadUrl = 'https://github.com/weisJ/auto-dark-mode/actions?query=workflow%3A%22Build+Native+Libraries%22'
+                def defaultLibraryName = project.property('defaultLibraryName')
+                def variantName = asVariantName(targetMachine)
+                def libraryFile = project.file("libraries/$variantName/$defaultLibraryName")
+                def relativePath = project.rootProject.relativePath(libraryFile)
+                if (!messageAlreadyLogged) {
+                    if (!libraryFile.exists()) {
+                        logger.warn("""${project.name}: Library $relativePath for targetMachine $variantName does not exist.
                             |${" ".multiply(project.name.size() + 1)} Download it from $downloadUrl
                             |""".stripMargin())
-            } else {
-                //Use provided library.
-                logger.warn("${project.name}: Using pre-build library $relativePath for targetMachine $variantName.")
-                task.into("$libraryPath/$variantName") { CopySpec spec ->
-                    spec.from(libraryFile)
+                    } else {
+                        //Use provided library.
+                        logger.warn("${project.name}: Using pre-build library $relativePath for targetMachine $variantName.")
+                    }
+                    messageAlreadyLogged = true
+                }
+                if (libraryFile.exists()) {
+                    return [libraryFile]
                 }
             }
+            return [] as List<File>
         }
     }
 
@@ -79,5 +111,29 @@ class UberJniJarPlugin implements Plugin<Project> {
         }
 
         return "$operatingSystemFamily-$architecture"
+    }
+
+    static Transformer<Iterable<JniLibrary>, JniLibrary> onlyBuildableVariant() {
+        return new Transformer<Iterable<JniLibrary>, JniLibrary>() {
+            @Override
+            List<JniLibrary> transform(JniLibrary it) {
+                if (it.sharedLibrary.buildable) {
+                    return [it]
+                }
+                return []
+            }
+        }
+    }
+
+    static Transformer<Iterable<JniLibrary>, JniLibrary> onlyUnbuildableVariant() {
+        return new Transformer<Iterable<JniLibrary>, JniLibrary>() {
+            @Override
+            List<JniLibrary> transform(JniLibrary it) {
+                if (!it.sharedLibrary.buildable) {
+                    return [it]
+                }
+                return []
+            }
+        }
     }
 }

--- a/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
+++ b/buildSrc/src/main/groovy/UberJniJarPlugin.groovy
@@ -1,6 +1,6 @@
 import dev.nokee.platform.jni.JniLibrary
 import dev.nokee.platform.jni.JniLibraryExtension
-import dev.nokee.runtime.nativebase.TargetMachine
+import dev.nokee.platform.nativebase.TargetMachine
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/buildSrc/src/main/groovy/UsePrebuiltBinariesWhenUnbuildablePlugin.groovy
+++ b/buildSrc/src/main/groovy/UsePrebuiltBinariesWhenUnbuildablePlugin.groovy
@@ -1,0 +1,29 @@
+import dev.nokee.platform.jni.JniLibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class UsePrebuiltBinariesWhenUnbuildablePlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        def library = project.extensions.getByType(JniLibraryExtension)
+        library.variants.configureEach {
+            if (!it.sharedLibrary.buildable) {
+                // Try to include the library file... if available
+                def downloadUrl = 'https://github.com/weisJ/auto-dark-mode/actions?query=workflow%3A%22Build+Native+Libraries%22'
+                def defaultLibraryName = project.property('defaultLibraryName')
+                def variantName = JniUtils.asVariantName(it.targetMachine)
+                def libraryFile = project.file("libraries/$variantName/$defaultLibraryName")
+                def relativePath = project.rootProject.relativePath(libraryFile)
+                if (!libraryFile.exists()) {
+                    project.logger.warn("""${project.name}: Library $relativePath for targetMachine $variantName does not exist.
+                            |${" ".multiply(project.name.size() + 1)} Download it from $downloadUrl
+                            |""".stripMargin())
+                } else {
+                    //Use provided library.
+                    project.logger.warn("${project.name}: Using pre-build library $relativePath for targetMachine $variantName.")
+                    it.nativeRuntimeFiles.setFrom(libraryFile)
+                }
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ auto-dark-mode.version                                    = 1.2.0-pre3
 com.github.vlsi.vlsi-release-plugins.version              = 1.70
 org.jetbrains.intellij.version                            = 0.4.18
 kotlin.version                                            = 1.3.72
-nokee.version                                             = 0.4.0-00ed537
+nokee.version                                             = 0.4.0-28912e7
 
 # Dependencies
 darklaf.version                                           = 2.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@ auto-dark-mode.version                                    = 1.2.0-pre3
 com.github.vlsi.vlsi-release-plugins.version              = 1.70
 org.jetbrains.intellij.version                            = 0.4.18
 kotlin.version                                            = 1.3.72
-nokee.version                                             = 0.4.0-28912e7
 
 # Dependencies
 darklaf.version                                           = 2.0.1

--- a/macos/build.gradle.kts
+++ b/macos/build.gradle.kts
@@ -1,4 +1,4 @@
-import UberJniJarPlugin.asVariantName
+import JniUtils.asVariantName
 
 plugins {
     java

--- a/macos/build.gradle.kts
+++ b/macos/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("dev.nokee.jni-library")
     id("dev.nokee.objective-cpp-language")
     `uber-jni-jar`
+    `use-prebuilt-binaries`
 }
 
 library {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,16 +1,4 @@
 pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        maven { url = uri("https://dl.bintray.com/nokeedev/distributions-snapshots") }
-    }
-    val nokeeVersion = extra["nokee.version"].toString()
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id.startsWith("dev.nokee.")) {
-                useModule("${requested.id.id}:${requested.id.id}.gradle.plugin:$nokeeVersion")
-            }
-        }
-    }
     plugins {
         fun String.v() = extra["$this.version"].toString()
         fun PluginDependenciesSpec.idv(id: String, key: String = id) = id(id) version key.v()

--- a/windows/build.gradle.kts
+++ b/windows/build.gradle.kts
@@ -1,4 +1,4 @@
-import UberJniJarPlugin.asVariantName
+import JniUtils.asVariantName
 
 plugins {
     java

--- a/windows/build.gradle.kts
+++ b/windows/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("dev.nokee.jni-library")
     id("dev.nokee.cpp-language")
     `uber-jni-jar`
+    `use-prebuilt-binaries`
 }
 
 library {


### PR DESCRIPTION
This PR should solve the issue you are seeing with the nightly release for 0.4: https://github.com/nokeedev/gradle-native/issues/45

The uber JNI JAR plugin was arranged to support the change with 0.4 around creating all variants regardless if they are buildable or not as well as differing the variant creation as late as possible. A new API was added to query if a binary is buildable or not.

Feel free to request any API that may help clean up the implementation code. Through this PR, I opened these new issues for APIs that I feel are missing: https://github.com/nokeedev/gradle-native/issues/48 and https://github.com/nokeedev/gradle-native/issues/47. Your comments are welcome.