### PR TITLE
WIP: Settings DSL 

### DIFF
--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           java-version: 11
       - name: Install libsigc++ and glibmm
-        run: sudo apt-get install libsigc++-2.0-dev libglibmm-2.4-dev
+        run: sudo apt-get install libsigc++-2.0-dev libglibmm-2.4-dev libgtk-3-dev
       - name: Build
         run: ./gradlew :auto-dark-mode-linux-gnome:build
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and an Objective-C++ toolchain when building on macOS (i.e. Gcc or Clang).
 At the moment, Linux requires a standard C++ toolchain like Gcc
 as well as the following packages.
 ```
-libsigc++-2.0-dev libglibmm-2.4-dev
+libsigc++-2.0-dev libglibmm-2.4-dev libgtk-3-dev
 ```
 
 

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
 
 dependencies {
     compileOnly("com.jetbrains.intellij.platform:util")
+    api("com.github.weisj:darklaf-native-utils")
 }

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
     compileOnly("com.jetbrains.intellij.platform:util")
     api("com.github.weisj:darklaf-native-utils")
+    compileOnly(kotlin("stdlib-jdk8"))
 }

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    kotlin("jvm")
 }
 
 dependencies {

--- a/base/src/main/java/com/github/weisj/darkmode/platform/AbstractPluginLibrary.java
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/AbstractPluginLibrary.java
@@ -22,30 +22,31 @@
  * SOFTWARE.
  *
  */
-package com.github.weisj.darkmode.platform.macos;
+package com.github.weisj.darkmode.platform;
 
-import com.github.weisj.darkmode.platform.AbstractPluginLibrary;
-import com.github.weisj.darkmode.platform.LibraryUtil;
-import com.github.weisj.darkmode.platform.PluginLogger;
+import com.github.weisj.darklaf.platform.AbstractLibrary;
 
-public class MacOSLibrary extends AbstractPluginLibrary {
+public abstract class AbstractPluginLibrary extends AbstractLibrary {
 
-    private static final String PROJECT_NAME = "auto-dark-mode-macos";
-    private static final String PATH = "/com/github/weisj/darkmode/" + PROJECT_NAME + "/macos-x86-64/";
-    private static final String DLL_NAME = "lib" + PROJECT_NAME + ".dylib";
-    private static final MacOSLibrary instance = new MacOSLibrary();
+    protected final PluginLogger logger;
 
-    static MacOSLibrary get() {
-        instance.updateLibrary();
-        return instance;
-    }
-
-    protected MacOSLibrary() {
-        super(PATH, DLL_NAME, PluginLogger.getLogger(MacOSLibrary.class));
+    public AbstractPluginLibrary(final String path, final String libraryName, final PluginLogger logger) {
+        super(path, libraryName, null);
+        this.logger = logger;
     }
 
     @Override
-    protected boolean canLoad() {
-        return LibraryUtil.isX64 && LibraryUtil.isMacOSMojave;
+    protected void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    protected void warning(String message) {
+        logger.warn(message);
+    }
+
+    @Override
+    protected void error(String message, Throwable e) {
+        logger.error(message, e);
     }
 }

--- a/base/src/main/java/com/github/weisj/darkmode/platform/AbstractThemeMonitor.java
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/AbstractThemeMonitor.java
@@ -24,11 +24,9 @@
  */
 package com.github.weisj.darkmode.platform;
 
-import com.intellij.openapi.diagnostic.Logger;
-
 public class AbstractThemeMonitor implements ThemeMonitor {
 
-    private static final Logger LOGGER = Logger.getInstance(AbstractThemeMonitor.class);
+    private static final PluginLogger LOGGER = PluginLogger.getLogger(AbstractThemeMonitor.class);
 
     private ThemeCallback onThemeChange;
     private ThemeMonitorService monitorService;

--- a/base/src/main/java/com/github/weisj/darkmode/platform/Notifications.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/Notifications.kt
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+package com.github.weisj.darkmode.platform
+
+object Notifications : NotificationsService by ServiceUtil.load(
+    NotificationsService::class.java).iterator().next()
+
+interface NotificationsService {
+    fun dispatchNotification(
+        message: String,
+        type: NotificationType = NotificationType.INFO
+    )
+}
+
+enum class NotificationType {
+    INFO, WARNING, ERROR
+}

--- a/base/src/main/java/com/github/weisj/darkmode/platform/Notifications.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/Notifications.kt
@@ -25,15 +25,39 @@
 package com.github.weisj.darkmode.platform
 
 object Notifications : NotificationsService by ServiceUtil.load(
-    NotificationsService::class.java).iterator().next()
+    NotificationsService::class.java).asSequence().firstOrNull()?:LogNotificationsService()
 
 interface NotificationsService {
+
+    /**
+     * Display the notification in the ide. HTML content is allowed.
+     *
+     * @param message the message
+     * @param type the notification type
+     * @param showSettingsLink Whether a link to the plugin settings should be added to the notification.
+     */
     fun dispatchNotification(
         message: String,
-        type: NotificationType = NotificationType.INFO
+        type: NotificationType = NotificationType.INFO,
+        showSettingsLink : Boolean = false
     )
 }
 
 enum class NotificationType {
     INFO, WARNING, ERROR
+}
+
+private class LogNotificationsService : NotificationsService {
+
+    override fun dispatchNotification(message: String, type: NotificationType, showSettingsLink: Boolean) {
+        when(type) {
+            NotificationType.INFO -> LOGGER.info(message)
+            NotificationType.WARNING -> LOGGER.warn(message)
+            NotificationType.ERROR -> LOGGER.error(message)
+        }
+    }
+
+    companion object {
+        private val LOGGER = PluginLogger.getLogger(Notifications::class.java)
+    }
 }

--- a/base/src/main/java/com/github/weisj/darkmode/platform/OneTimeAction.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/OneTimeAction.kt
@@ -1,0 +1,12 @@
+package com.github.weisj.darkmode.platform
+
+class OneTimeAction(private val action : () -> Unit) {
+    var executed : Boolean = false
+
+    operator fun invoke() {
+        if (!executed) {
+            action()
+            executed = true
+        }
+    }
+}

--- a/base/src/main/java/com/github/weisj/darkmode/platform/PluginLogger.java
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/PluginLogger.java
@@ -22,30 +22,39 @@
  * SOFTWARE.
  *
  */
-package com.github.weisj.darkmode.platform.macos;
+package com.github.weisj.darkmode.platform;
 
-import com.github.weisj.darkmode.platform.AbstractPluginLibrary;
-import com.github.weisj.darkmode.platform.LibraryUtil;
-import com.github.weisj.darkmode.platform.PluginLogger;
+import com.intellij.openapi.diagnostic.Logger;
 
-public class MacOSLibrary extends AbstractPluginLibrary {
+public class PluginLogger {
 
-    private static final String PROJECT_NAME = "auto-dark-mode-macos";
-    private static final String PATH = "/com/github/weisj/darkmode/" + PROJECT_NAME + "/macos-x86-64/";
-    private static final String DLL_NAME = "lib" + PROJECT_NAME + ".dylib";
-    private static final MacOSLibrary instance = new MacOSLibrary();
-
-    static MacOSLibrary get() {
-        instance.updateLibrary();
-        return instance;
+    public static PluginLogger getLogger(final Class<?> type) {
+        return new PluginLogger(Logger.getInstance(type));
     }
 
-    protected MacOSLibrary() {
-        super(PATH, DLL_NAME, PluginLogger.getLogger(MacOSLibrary.class));
+    private final Logger logger;
+
+    public PluginLogger(final Logger logger) {
+        this.logger = logger;
     }
 
-    @Override
-    protected boolean canLoad() {
-        return LibraryUtil.isX64 && LibraryUtil.isMacOSMojave;
+    public void info(final String msg) {
+        logger.info(msg);
+    }
+
+    public void warn(final String msg) {
+        logger.warn(msg);
+    }
+
+    public void error(final String msg) {
+        logger.error(msg);
+    }
+
+    public void error(final Throwable e) {
+        logger.error(e);
+    }
+
+    public void error(final String msg, final Throwable e) {
+        logger.error(msg, e);
     }
 }

--- a/base/src/main/java/com/github/weisj/darkmode/platform/ServiceUtil.java
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/ServiceUtil.java
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+package com.github.weisj.darkmode.platform;
+
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+public class ServiceUtil {
+
+    /**
+     * Creates a new service loader for the given service type, using the
+     * current appropriate Classloader. This method should be used instal of
+     * {@link ServiceLoader#load(Class)} for plugins running on the IntelliJ platform.
+     * https://jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_class_loaders.html#using-serviceloader
+     *
+     * @throws ServiceConfigurationError
+     *                                   if the service type is not accessible to the caller or the
+     *                                   caller is in an explicit module and its module descriptor does
+     *                                   not declare that it uses {@code service}
+     */
+    public static <T> ServiceLoader<T> load(final Class<T> serviceClass) {
+        ClassLoader current = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(serviceClass.getClassLoader());
+            return ServiceLoader.load(serviceClass);
+        } finally {
+            Thread.currentThread().setContextClassLoader(current);
+        }
+    }
+}

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Observable.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Observable.kt
@@ -1,0 +1,103 @@
+package com.github.weisj.darkmode.platform.settings
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.*
+
+typealias BiConsumer<T> = (T, T) -> Unit
+
+class ObservableManager<T> {
+    private val properties = mutableMapOf<String, Any>()
+    private val listeners = mutableMapOf<String, MutableList<BiConsumer<Any>>>()
+
+    private fun updateValue(name: String, value: Any) {
+        val old = properties.put(name, value)!!
+        listeners[name]?.forEach { it(old, value) }
+    }
+
+    fun registerListener(name: String, biConsumer: BiConsumer<Any>) {
+        listeners.getOrPut(name) { mutableListOf() }.add(biConsumer)
+        properties[name]?.let { biConsumer(it, it) }
+    }
+
+    inline fun <reified V : Any> registerListener(property: KProperty1<T, V>, crossinline consumer: BiConsumer<V>) =
+        registerListener(property.name) { old, new -> consumer(old as V, new as V) }
+
+    inner class WrappingRWProperty<V : Any>(
+        prop: KProperty<*>,
+        value: V,
+        private val type: KClass<V>
+    ) : ReadWriteProperty<T, V> {
+
+        init {
+            properties[prop.name] = value
+        }
+
+        @ExperimentalStdlibApi
+        override operator fun getValue(thisRef: T, property: KProperty<*>) =
+            type.safeCast(properties[property.name])!!
+
+        override operator fun setValue(thisRef: T, property: KProperty<*>, value: V) =
+            updateValue(property.name, value)
+    }
+}
+
+class WriteDelegateRWProperty<T, V>(
+    private val valueProp: KMutableProperty0<V>,
+    private val delegate: ReadWriteProperty<T, V>
+) : ReadWriteProperty<T, V> {
+    override fun getValue(thisRef: T, property: KProperty<*>): V = valueProp.get()
+
+    override fun setValue(thisRef: T, property: KProperty<*>, value: V) {
+        valueProp.set(value)
+        delegate.setValue(thisRef, property, value)
+    }
+}
+
+interface DelegateProvider<T, V> {
+    operator fun provideDelegate(
+        thisRef: T,
+        prop: KProperty<*>
+    ): ReadWriteProperty<T, V>
+}
+
+class ObservableValue<T, V : Any>(
+    private val delegate: ObservableManager<T>,
+    private val value: V,
+    private val type: KClass<V>
+) : DelegateProvider<T, V> {
+    override operator fun provideDelegate(
+        thisRef: T,
+        prop: KProperty<*>
+    ): ReadWriteProperty<T, V> = delegate.WrappingRWProperty(prop, value, type)
+}
+
+class ObservablePropertyValue<T, V : Any>(
+    private val delegate: ObservableManager<T>,
+    private val property: KMutableProperty0<V>,
+    private val type: KClass<V>
+) : DelegateProvider<T, V> {
+    override operator fun provideDelegate(
+        thisRef: T,
+        prop: KProperty<*>
+    ): ReadWriteProperty<T, V> =
+        WriteDelegateRWProperty(property, delegate.WrappingRWProperty(prop, property.get(), type))
+}
+
+interface Observable<T> {
+    val manager: ObservableManager<T>
+}
+
+open class DefaultObservable<T> : Observable<T> {
+    override val manager = ObservableManager<T>()
+}
+
+inline fun <T, reified V : Any> Observable<T>.observable(value: V): DelegateProvider<T, V> =
+    ObservableValue(manager, value, V::class)
+
+fun <T, V : Any> Observable<T>.observableProperty(prop: KMutableProperty0<V>): DelegateProvider<T, V> =
+    ObservablePropertyValue(manager, prop, prop.get().javaClass.kotlin)
+
+inline fun <T, reified V : Any> Observable<T>.registerListener(
+    property: KProperty1<T, V>,
+    crossinline consumer: BiConsumer<V>
+) = manager.registerListener(property, consumer)

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Observable.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Observable.kt
@@ -41,18 +41,6 @@ class ObservableManager<T> {
     }
 }
 
-class WriteDelegateRWProperty<T, V>(
-    private val valueProp: KMutableProperty0<V>,
-    private val delegate: ReadWriteProperty<T, V>
-) : ReadWriteProperty<T, V> {
-    override fun getValue(thisRef: T, property: KProperty<*>): V = valueProp.get()
-
-    override fun setValue(thisRef: T, property: KProperty<*>, value: V) {
-        valueProp.set(value)
-        delegate.setValue(thisRef, property, value)
-    }
-}
-
 interface DelegateProvider<T, V> {
     operator fun provideDelegate(
         thisRef: T,
@@ -71,18 +59,6 @@ class ObservableValue<T, V : Any>(
     ): ReadWriteProperty<T, V> = delegate.WrappingRWProperty(prop, value, type)
 }
 
-class ObservablePropertyValue<T, V : Any>(
-    private val delegate: ObservableManager<T>,
-    private val property: KMutableProperty0<V>,
-    private val type: KClass<V>
-) : DelegateProvider<T, V> {
-    override operator fun provideDelegate(
-        thisRef: T,
-        prop: KProperty<*>
-    ): ReadWriteProperty<T, V> =
-        WriteDelegateRWProperty(property, delegate.WrappingRWProperty(prop, property.get(), type))
-}
-
 interface Observable<T> {
     val manager: ObservableManager<T>
 }
@@ -93,9 +69,6 @@ open class DefaultObservable<T> : Observable<T> {
 
 inline fun <T, reified V : Any> Observable<T>.observable(value: V): DelegateProvider<T, V> =
     ObservableValue(manager, value, V::class)
-
-fun <T, V : Any> Observable<T>.observableProperty(prop: KMutableProperty0<V>): DelegateProvider<T, V> =
-    ObservablePropertyValue(manager, prop, prop.get().javaClass.kotlin)
 
 inline fun <T, reified V : Any> Observable<T>.registerListener(
     property: KProperty1<T, V>,

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
@@ -1,6 +1,8 @@
 package com.github.weisj.darkmode.platform.settings
 
 import kotlin.reflect.KMutableProperty0
+import kotlin.reflect.KProperty
+import kotlin.reflect.KProperty0
 
 /**
  * Cast the property to the specified type if applicable for read and write operations.
@@ -34,3 +36,7 @@ inline fun <reified T, R : Any> KMutableProperty0<R>.withInType(): KMutablePrope
         null
     }
 }
+
+operator fun <T> KMutableProperty0<T>.setValue(target: Any?, property: KProperty<*>, value: T) = set(value)
+
+operator fun <T> KProperty0<T>.getValue(target: Any?, property: KProperty<*>): T = get()

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
@@ -1,0 +1,37 @@
+package com.github.weisj.darkmode.platform.settings
+
+import com.intellij.util.castSafelyTo
+import kotlin.reflect.KMutableProperty0
+
+/**
+ * Cast the property to the specified type if applicable for read and write operations.
+ */
+inline fun <reified T> KMutableProperty0<Any>.withType(): KMutableProperty0<T>? {
+    return if (get().javaClass.kotlin == T::class) {
+        this.castSafelyTo<KMutableProperty0<T>>()
+    } else {
+        null
+    }
+}
+
+/**
+ * Cast the property to the specified type if applicable for read operations.
+ */
+inline fun <reified T> KMutableProperty0<Any>.withOutType(): KMutableProperty0<T>? {
+    return if (T::class.java.isAssignableFrom(get().javaClass)) {
+        this.castSafelyTo<KMutableProperty0<T>>()
+    } else {
+        null
+    }
+}
+
+/**
+ * Cast the property to the specified type if applicable for write operations.
+ */
+inline fun <reified T> KMutableProperty0<Any>.withInType(): KMutableProperty0<T>? {
+    return if (get().javaClass.isAssignableFrom(T::class.java)) {
+        this.castSafelyTo<KMutableProperty0<T>>()
+    } else {
+        null
+    }
+}

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
@@ -1,6 +1,5 @@
 package com.github.weisj.darkmode.platform.settings
 
-import com.intellij.util.castSafelyTo
 import kotlin.reflect.KMutableProperty0
 
 /**

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Properties.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KMutableProperty0
 /**
  * Cast the property to the specified type if applicable for read and write operations.
  */
-inline fun <reified T> KMutableProperty0<Any>.withType(): KMutableProperty0<T>? {
+inline fun <reified T, R : Any> KMutableProperty0<R>.withType(): KMutableProperty0<T>? {
     return if (get().javaClass.kotlin == T::class) {
         this.castSafelyTo<KMutableProperty0<T>>()
     } else {
@@ -17,7 +17,7 @@ inline fun <reified T> KMutableProperty0<Any>.withType(): KMutableProperty0<T>? 
 /**
  * Cast the property to the specified type if applicable for read operations.
  */
-inline fun <reified T> KMutableProperty0<Any>.withOutType(): KMutableProperty0<T>? {
+inline fun <reified T, R : Any> KMutableProperty0<R>.withOutType(): KMutableProperty0<T>? {
     return if (T::class.java.isAssignableFrom(get().javaClass)) {
         this.castSafelyTo<KMutableProperty0<T>>()
     } else {
@@ -28,7 +28,7 @@ inline fun <reified T> KMutableProperty0<Any>.withOutType(): KMutableProperty0<T
 /**
  * Cast the property to the specified type if applicable for write operations.
  */
-inline fun <reified T> KMutableProperty0<Any>.withInType(): KMutableProperty0<T>? {
+inline fun <reified T, R : Any> KMutableProperty0<R>.withInType(): KMutableProperty0<T>? {
     return if (get().javaClass.isAssignableFrom(T::class.java)) {
         this.castSafelyTo<KMutableProperty0<T>>()
     } else {

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
@@ -1,6 +1,5 @@
 package com.github.weisj.darkmode.platform.settings
 
-import com.intellij.util.castSafelyTo
 import kotlin.reflect.KMutableProperty0
 
 interface SettingsContainer : SettingsGroup {

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
@@ -76,8 +76,8 @@ interface PersistentValueProperty<T> : TransformingValueProperty<T, String>
 fun ValueProperty<*>.toTransformer(): TransformingValueProperty<Any, Any>? =
     castSafelyTo<TransformingValueProperty<Any, Any>>()
 
-inline fun <reified T: Any> ValueProperty<T>.asPersistent() : PersistentValueProperty<T>?
-        = castSafelyTo<PersistentValueProperty<T>>()
+inline fun <reified T : Any> ValueProperty<T>.asPersistent(): PersistentValueProperty<T>? =
+    castSafelyTo<PersistentValueProperty<T>>()
 
 /**
  * The effective value of the property. If the property is a transforming property the
@@ -93,10 +93,10 @@ val <R, T> TransformingValueProperty<R, T>.effective: KMutableProperty0<R>
 
 
 class SimpleValueProperty<T> internal constructor(
-    descr: String?,
+    description: String?,
     private val property: KMutableProperty0<T>
 ) : ValueProperty<T> {
-    override val description: String = descr ?: property.name
+    override val description: String = description ?: property.name
     override val name: String = property.name
     override var value: T
         get() = property.get()

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
@@ -1,51 +1,18 @@
 package com.github.weisj.darkmode.platform.settings
 
 import com.intellij.util.castSafelyTo
-import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty0
 
-/**
- * Cast the property to the specified type if applicable for read and write operations.
- */
-inline fun <reified T> KMutableProperty0<Any>.withType(): KMutableProperty0<T>? {
-    return if (get().javaClass.kotlin == T::class) {
-        this.castSafelyTo<KMutableProperty0<T>>()
-    } else {
-        null
-    }
-}
-
-/**
- * Cast the property to the specified type if applicable for read operations.
- */
-inline fun <reified T> KMutableProperty0<Any>.withOutType(): KMutableProperty0<T>? {
-    return if (T::class.java.isAssignableFrom(get().javaClass)) {
-        this.castSafelyTo<KMutableProperty0<T>>()
-    } else {
-        null
-    }
-}
-
-/**
- * Cast the property to the specified type if applicable for write operations.
- */
-inline fun <reified T> KMutableProperty0<Any>.withInType(): KMutableProperty0<T>? {
-    return if (get().javaClass.isAssignableFrom(T::class.java)) {
-        this.castSafelyTo<KMutableProperty0<T>>()
-    } else {
-        null
-    }
-}
-
 interface SettingsContainer : SettingsGroup {
-    val settings: MutableMap<KClass<*>, MutableMap<String, ValueProperty<Any>>>
-    val namedGroups: MutableList<SettingsGroup>
+    val namedGroups: MutableList<NamedSettingsGroup>
     val unnamedGroup: SettingsGroup
 
     @JvmDefault
     fun allProperties(): List<ValueProperty<Any>> {
-        return settings.values.flatMap { it.values }
+        return namedGroups.flatten() + unnamedGroup
     }
+
+    fun isEnabled(): Boolean
 }
 
 /**
@@ -55,40 +22,35 @@ interface SettingsContainer : SettingsGroup {
  * All properties not contained inside a {@SettingsGroup} will automatically belong
  * to the unnamed group of the container.
  */
-open class DefaultSettingsContainer(
-    override val unnamedGroup: SettingsGroup = DefaultSettingsGroup()
+abstract class DefaultSettingsContainer private constructor(
+    override val unnamedGroup: SettingsGroup
 ) : SettingsContainer, SettingsGroup by unnamedGroup {
-    override val settings: MutableMap<KClass<*>, MutableMap<String, ValueProperty<Any>>> = mutableMapOf()
-    override val namedGroups: MutableList<SettingsGroup> = mutableListOf()
 
-    init {
-        unnamedGroup.parent = this
-    }
+    constructor() : this(DefaultSettingsGroup())
+
+    override val namedGroups: MutableList<NamedSettingsGroup> = mutableListOf()
 }
 
-inline fun <reified T> SettingsGroup.add(property: ValueProperty<T>) {
-    val type = T::class
-    val list = parent.settings[type] ?: mutableMapOf()
-    list[property.description] = property.castSafelyTo()!!
-    parent.settings[type] = list
-    properties.add(property.castSafelyTo()!!)
+fun <T> SettingsGroup.add(property: ValueProperty<T>) {
+    this.add(property.castSafelyTo()!!)
 }
 
 /**
  * Provides grouping for {@link ValueProperty}s
  */
-interface SettingsGroup {
+typealias SettingsGroup = MutableList<ValueProperty<Any>>
+
+interface NamedSettingsGroup : SettingsGroup {
     val name: String
-    val properties: MutableList<ValueProperty<Any>>
-    var parent: SettingsContainer
 }
 
-class DefaultSettingsGroup(
-    override val name: String = "",
-    override val properties: MutableList<ValueProperty<Any>> = mutableListOf()
-) : SettingsGroup {
-    override lateinit var parent: SettingsContainer
-}
+open class DefaultSettingsGroup internal constructor(
+    private val properties: MutableList<ValueProperty<Any>> = mutableListOf()
+) : SettingsGroup by properties
+
+class DefaultNamedSettingsGroup internal constructor(
+    override val name: String
+) : DefaultSettingsGroup(), NamedSettingsGroup
 
 /**
  * Wrapper for properties that provides a description and parser/writer used
@@ -96,87 +58,139 @@ class DefaultSettingsGroup(
  */
 interface ValueProperty<T> {
     val description: String
-    var property: KMutableProperty0<T>
-    val parser: (String) -> T
-    val writer: (T) -> String
+    val name: String
+    var value: T
 }
 
-class SimpleValueProperty<T>(
-    override val description: String,
-    override var property: KMutableProperty0<T>,
-    override val parser: (s: String) -> T,
-    override val writer: (T) -> String = { it.toString() }
-) : ValueProperty<T>
+/**
+ * Property with a backing value that has a different type than the exposed value.
+ */
+interface TransformingValueProperty<R, T> : ValueProperty<T> {
+    var backingValue: R
+}
+
+/**
+ * Property that can be stored in String format.
+ */
+interface PersistentValueProperty<T> : TransformingValueProperty<T, String>
+
+fun ValueProperty<Any>.asPersistent() : PersistentValueProperty<Any>? =
+    castSafelyTo<PersistentValueProperty<Any>>()
+
+class SimpleValueProperty<T> internal constructor(
+    descr: String?,
+    private val property: KMutableProperty0<T>
+) : ValueProperty<T> {
+    override val description: String = descr ?: property.name
+    override val name: String = property.name
+    override var value: T
+        get() = property.get()
+        set(v) = property.set(v)
+}
+
+open class SimpleTransformingValueProperty<R, T> internal constructor(
+    private val delegate: ValueProperty<R>,
+    private var transformer: Transformer<R, T>
+) : TransformingValueProperty<R, T> {
+    override val description = delegate.description
+    override val name = delegate.name
+    override var value: T
+        get() = transformer.read(delegate.value)
+        set(v) {
+            delegate.value = transformer.write(v)
+        }
+    override var backingValue: R
+        get() = delegate.value
+        set(v) {
+            delegate.value = v
+        }
+}
+
+class SimplePersistentValueProperty<R>(
+    delegate: ValueProperty<R>,
+    transformer: Transformer<R, String>
+) : SimpleTransformingValueProperty<R, String>(delegate, transformer),
+    PersistentValueProperty<R>
 
 /**
  * Property that has a limited set of values the property can take on.
  */
-class ChoiceProperty<T>(
-    override val description: String,
-    override var property: KMutableProperty0<T>,
-    override val parser: (s: String) -> T,
-    override val writer: (T) -> String = { it.toString() }
-) : ValueProperty<T> {
-    var options: List<T> = ArrayList()
-    var renderer: (T) -> String = { it.toString() }
+abstract class ChoiceProperty<R, T> internal constructor(
+    private val delegateProperty: TransformingValueProperty<R, T>
+) : TransformingValueProperty<R, T> by delegateProperty {
+    var choiceValue: R
+        get() = backingValue
+        set(v) {
+            backingValue = v
+        }
+    var choices: List<R> = ArrayList()
+    var renderer: (R) -> String = { it.toString() }
 }
 
+class TransformingChoiceProperty<R, T> internal constructor(
+    property: TransformingValueProperty<R, T>
+) : ChoiceProperty<R, T>(property) {
+    constructor(property: ValueProperty<R>, transformer: Transformer<R, T>)
+            : this(SimpleTransformingValueProperty(property, transformer))
+}
+
+class PersistentChoiceProperty<R>(
+    property: PersistentValueProperty<R>
+) : ChoiceProperty<R, String>(property),
+    PersistentValueProperty<R> {
+    constructor(property: ValueProperty<R>, transformer: Transformer<R, String>)
+            : this(SimplePersistentValueProperty(property, transformer))
+}
+
+
 fun SettingsContainer.group(name: String, init: SettingsGroup.() -> Unit) {
-    val group = DefaultSettingsGroup(name)
-    group.parent = this
-    parent.namedGroups.add(group)
+    val group = DefaultNamedSettingsGroup(name)
+    namedGroups.add(group)
     group.init()
 }
 
-inline fun <reified T> SettingsGroup.property(
-    description: String,
-    value: KMutableProperty0<T>,
-    noinline parser: (s: String) -> T
-) = add(SimpleValueProperty(description, value, parser))
+fun SettingsContainer.unnamed(init: SettingsGroup.() -> Unit) = this.init()
 
-inline fun <reified T> SettingsGroup.property(
-    description: String,
-    value: KMutableProperty0<T>,
-    noinline parser: (String) -> T,
-    noinline writer: (T) -> String
-) = add(SimpleValueProperty(description, value, parser, writer))
+fun <T> SettingsGroup.property(
+    description: String? = null,
+    value: KMutableProperty0<T>
+) = add(SimpleValueProperty(description, value))
 
-inline fun <reified T> SettingsGroup.choiceProperty(
-    description: String,
-    value: KMutableProperty0<T>,
-    noinline parser: (s: String) -> T,
-    init: ChoiceProperty<T>.() -> Unit
-) = add(ChoiceProperty(description, value, parser).also { it.init() })
+fun <R, T> SettingsGroup.property(
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, T>
+) = add(SimpleTransformingValueProperty(SimpleValueProperty(description, value), transformer))
 
-inline fun <reified T> SettingsGroup.choiceProperty(
-    description: String,
-    value: KMutableProperty0<T>,
-    noinline parser: (String) -> T,
-    noinline writer: (T) -> String,
-    init: ChoiceProperty<T>.() -> Unit
-) = add(ChoiceProperty(description, value, parser, writer).also { it.init() })
+fun SettingsGroup.stringProperty(description: String? = null, value: KMutableProperty0<String>) =
+    property(description, value)
 
-inline fun <reified T> SettingsGroup.choiceProperty(
-    value: KMutableProperty0<T>,
-    noinline parser: (String) -> T,
-    noinline writer: (T) -> String,
-    init: ChoiceProperty<T>.() -> Unit
-) = choiceProperty(value.name, value, parser, writer, init)
+fun SettingsGroup.booleanProperty(description: String? = null, value: KMutableProperty0<Boolean>) =
+    property(description, value)
 
-inline fun <reified T> SettingsGroup.property(value: KMutableProperty0<T>, noinline parser: (s: String) -> T) =
-    property(value.name, value, parser)
+fun <R, T> SettingsGroup.choiceProperty(
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, T>,
+    init: ChoiceProperty<R, T>.() -> Unit = {}
+) = add(TransformingChoiceProperty(SimpleValueProperty(description, value), transformer).also(init))
 
-inline fun <reified T> SettingsGroup.property(
-    value: KMutableProperty0<T>,
-    noinline parser: (String) -> T,
-    noinline writer: (T) -> String
-) = property(value.name, value, parser, writer)
+fun <R> SettingsGroup.persistentProperty(
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, String>
+) = add(SimplePersistentValueProperty(SimpleValueProperty(description, value), transformer))
 
-fun SettingsGroup.stringProperty(description: String, value: KMutableProperty0<String>) =
-    property(description, value) { it }
+fun SettingsGroup.persistentStringProperty(description: String? = null, value: KMutableProperty0<String>) =
+    persistentProperty(description, value, constantTransformer())
 
-fun SettingsGroup.booleanProperty(description: String, value: KMutableProperty0<Boolean>) =
-    property(description, value, String::toBoolean)
+fun SettingsGroup.persistentBooleanProperty(description: String? = null, value: KMutableProperty0<Boolean>) =
+    persistentProperty(description, value, Transformer(String::toBoolean, Boolean::toString))
 
-fun SettingsGroup.booleanProperty(value: KMutableProperty0<Boolean>) =
-    booleanProperty(value.name, value)
+fun <R> SettingsGroup.persistentChoiceProperty(
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, String>,
+    init: ChoiceProperty<R, String>.() -> Unit = {}
+) = add(PersistentChoiceProperty(SimpleValueProperty(description, value), transformer).also(init))
+

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
@@ -160,7 +160,7 @@ class PersistentChoiceProperty<R>(
 }
 
 interface PropertyController<T> {
-    val predicate: (T?) -> Boolean
+    var predicate: (T?) -> Boolean
     val controlled: MutableSet<Lazy<ValueProperty<*>>>
 
     @JvmDefault
@@ -174,9 +174,11 @@ interface PropertyController<T> {
     }
 }
 
-class SimplePropertyController<T>(override val predicate: (T?) -> Boolean) : PropertyController<T> {
+class SimplePropertyController<T>(override var predicate: (T?) -> Boolean) : PropertyController<T> {
     override val controlled : MutableSet<Lazy<ValueProperty<*>>> = mutableSetOf()
 }
+
+fun <T> PropertyController<T>.inverted() = predicate.let { predicate = { t -> !it(t) } }
 
 class SimpleBooleanProperty(
     delegate: SimpleValueProperty<Boolean>,

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Settings.kt
@@ -1,0 +1,182 @@
+package com.github.weisj.darkmode.platform.settings
+
+import com.intellij.util.castSafelyTo
+import kotlin.reflect.KClass
+import kotlin.reflect.KMutableProperty0
+
+/**
+ * Cast the property to the specified type if applicable for read and write operations.
+ */
+inline fun <reified T> KMutableProperty0<Any>.withType(): KMutableProperty0<T>? {
+    return if (get().javaClass.kotlin == T::class) {
+        this.castSafelyTo<KMutableProperty0<T>>()
+    } else {
+        null
+    }
+}
+
+/**
+ * Cast the property to the specified type if applicable for read operations.
+ */
+inline fun <reified T> KMutableProperty0<Any>.withOutType(): KMutableProperty0<T>? {
+    return if (T::class.java.isAssignableFrom(get().javaClass)) {
+        this.castSafelyTo<KMutableProperty0<T>>()
+    } else {
+        null
+    }
+}
+
+/**
+ * Cast the property to the specified type if applicable for write operations.
+ */
+inline fun <reified T> KMutableProperty0<Any>.withInType(): KMutableProperty0<T>? {
+    return if (get().javaClass.isAssignableFrom(T::class.java)) {
+        this.castSafelyTo<KMutableProperty0<T>>()
+    } else {
+        null
+    }
+}
+
+interface SettingsContainer : SettingsGroup {
+    val settings: MutableMap<KClass<*>, MutableMap<String, ValueProperty<Any>>>
+    val namedGroups: MutableList<SettingsGroup>
+    val unnamedGroup: SettingsGroup
+
+    @JvmDefault
+    fun allProperties(): List<ValueProperty<Any>> {
+        return settings.values.flatMap { it.values }
+    }
+}
+
+/**
+ * Container for {@link ValueProperty}s. Properties can be group into
+ * logical units using a {@SettingsGroup}.
+ *
+ * All properties not contained inside a {@SettingsGroup} will automatically belong
+ * to the unnamed group of the container.
+ */
+open class DefaultSettingsContainer(
+    override val unnamedGroup: SettingsGroup = DefaultSettingsGroup()
+) : SettingsContainer, SettingsGroup by unnamedGroup {
+    override val settings: MutableMap<KClass<*>, MutableMap<String, ValueProperty<Any>>> = mutableMapOf()
+    override val namedGroups: MutableList<SettingsGroup> = mutableListOf()
+
+    init {
+        unnamedGroup.parent = this
+    }
+}
+
+inline fun <reified T> SettingsGroup.add(property: ValueProperty<T>) {
+    val type = T::class
+    val list = parent.settings[type] ?: mutableMapOf()
+    list[property.description] = property.castSafelyTo()!!
+    parent.settings[type] = list
+    properties.add(property.castSafelyTo()!!)
+}
+
+/**
+ * Provides grouping for {@link ValueProperty}s
+ */
+interface SettingsGroup {
+    val name: String
+    val properties: MutableList<ValueProperty<Any>>
+    var parent: SettingsContainer
+}
+
+class DefaultSettingsGroup(
+    override val name: String = "",
+    override val properties: MutableList<ValueProperty<Any>> = mutableListOf()
+) : SettingsGroup {
+    override lateinit var parent: SettingsContainer
+}
+
+/**
+ * Wrapper for properties that provides a description and parser/writer used
+ * for persistent storage.
+ */
+interface ValueProperty<T> {
+    val description: String
+    var property: KMutableProperty0<T>
+    val parser: (String) -> T
+    val writer: (T) -> String
+}
+
+class SimpleValueProperty<T>(
+    override val description: String,
+    override var property: KMutableProperty0<T>,
+    override val parser: (s: String) -> T,
+    override val writer: (T) -> String = { it.toString() }
+) : ValueProperty<T>
+
+/**
+ * Property that has a limited set of values the property can take on.
+ */
+class ChoiceProperty<T>(
+    override val description: String,
+    override var property: KMutableProperty0<T>,
+    override val parser: (s: String) -> T,
+    override val writer: (T) -> String = { it.toString() }
+) : ValueProperty<T> {
+    var options: List<T> = ArrayList()
+    var renderer: (T) -> String = { it.toString() }
+}
+
+fun SettingsContainer.group(name: String, init: SettingsGroup.() -> Unit) {
+    val group = DefaultSettingsGroup(name)
+    group.parent = this
+    parent.namedGroups.add(group)
+    group.init()
+}
+
+inline fun <reified T> SettingsGroup.property(
+    description: String,
+    value: KMutableProperty0<T>,
+    noinline parser: (s: String) -> T
+) = add(SimpleValueProperty(description, value, parser))
+
+inline fun <reified T> SettingsGroup.property(
+    description: String,
+    value: KMutableProperty0<T>,
+    noinline parser: (String) -> T,
+    noinline writer: (T) -> String
+) = add(SimpleValueProperty(description, value, parser, writer))
+
+inline fun <reified T> SettingsGroup.choiceProperty(
+    description: String,
+    value: KMutableProperty0<T>,
+    noinline parser: (s: String) -> T,
+    init: ChoiceProperty<T>.() -> Unit
+) = add(ChoiceProperty(description, value, parser).also { it.init() })
+
+inline fun <reified T> SettingsGroup.choiceProperty(
+    description: String,
+    value: KMutableProperty0<T>,
+    noinline parser: (String) -> T,
+    noinline writer: (T) -> String,
+    init: ChoiceProperty<T>.() -> Unit
+) = add(ChoiceProperty(description, value, parser, writer).also { it.init() })
+
+inline fun <reified T> SettingsGroup.choiceProperty(
+    value: KMutableProperty0<T>,
+    noinline parser: (String) -> T,
+    noinline writer: (T) -> String,
+    init: ChoiceProperty<T>.() -> Unit
+) = choiceProperty(value.name, value, parser, writer, init)
+
+inline fun <reified T> SettingsGroup.property(value: KMutableProperty0<T>, noinline parser: (s: String) -> T) =
+    property(value.name, value, parser)
+
+inline fun <reified T> SettingsGroup.property(
+    value: KMutableProperty0<T>,
+    noinline parser: (String) -> T,
+    noinline writer: (T) -> String
+) = property(value.name, value, parser, writer)
+
+fun SettingsGroup.stringProperty(description: String, value: KMutableProperty0<String>) =
+    property(description, value) { it }
+
+fun SettingsGroup.booleanProperty(description: String, value: KMutableProperty0<Boolean>) =
+    property(description, value, String::toBoolean)
+
+fun SettingsGroup.booleanProperty(value: KMutableProperty0<Boolean>) =
+    booleanProperty(value.name, value)

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/SettingsBuilder.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/SettingsBuilder.kt
@@ -1,0 +1,138 @@
+package com.github.weisj.darkmode.platform.settings
+
+import kotlin.reflect.KMutableProperty0
+
+private data class Counter(var count : Int) {
+
+    fun increment() : Int {
+        val c = count
+        count++
+        return c
+    }
+}
+
+private val SettingsContainer.unnamedGroupCounter by lazy { Counter(0) }
+
+fun SettingsContainer.group(name: String = "", init: SettingsGroup.() -> Unit) : SettingsGroup {
+    val identifier = if (name.isEmpty()) "${this.identifier}:group_${unnamedGroupCounter.increment()}" else null
+    val group = DefaultNamedSettingsGroup(this, name, identifier)
+    namedGroups.add(group)
+    group.init()
+    return group
+}
+
+fun SettingsContainer.unnamedGroup(init: SettingsGroup.() -> Unit) : SettingsGroup = this.also(init)
+
+fun SettingsContainer.hidden(init: SettingsGroup.() -> Unit) : SettingsGroup = hiddenGroup.also(init)
+
+fun <T : ValueProperty<T>> SettingsGroup.property(property: T, init: T.() -> Unit = {}): T =
+    property.also { it.init(); add(it) }
+
+fun <T : Any> SettingsGroup.property(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<T>,
+    init: SimpleValueProperty<T>.() -> Unit = {}
+): ValueProperty<T> =
+    SimpleValueProperty(name, description, value, this).also { it.init(); add(it) }
+
+fun <R : Any, T : Any> SettingsGroup.property(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, T>,
+    init: SimpleValueProperty<R>.() -> Unit = {}
+): TransformingValueProperty<R, T> =
+    SimpleTransformingValueProperty(
+        SimpleValueProperty(name, description, value, this).also(init),
+        transformer
+    ).also { add(it) }
+
+fun SettingsGroup.stringProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<String>
+): ValueProperty<String> = property(name, description, value)
+
+fun SettingsGroup.booleanProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<Boolean>,
+    init: SimpleBooleanProperty.() -> Unit = {}
+): ValueProperty<Boolean> =
+    SimpleBooleanProperty(SimpleValueProperty(name, description, value, this)).also { it.init(); add(it) }
+
+fun <R : Any, T : Any> SettingsGroup.choiceProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, T>,
+    init: ChoiceProperty<R, T>.() -> Unit = {}
+): ChoiceProperty<R, T> =
+    TransformingChoiceProperty(SimpleValueProperty(name, description, value, this), transformer).also {
+        it.init(); add(
+        it
+    )
+    }
+
+fun <T : Any> SettingsGroup.choiceProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<T>,
+    init: ChoiceProperty<T, T>.() -> Unit = {}
+): ChoiceProperty<T, T> =
+    TransformingChoiceProperty<T, T>(
+        SimpleValueProperty(name, description, value, this),
+        identityTransformer()
+    ).also { it.init(); add(it) }
+
+fun <R : Any> SettingsGroup.persistentProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, String>,
+    init: SimpleValueProperty<R>.() -> Unit = {}
+): PersistentValueProperty<R> =
+    SimplePersistentValueProperty(
+        SimpleValueProperty(name, description, value, this).also(init),
+        transformer
+    ).also { add(it) }
+
+fun SettingsGroup.persistentStringProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<String>
+): ValueProperty<String> = persistentProperty(name, description, value, identityTransformer())
+
+fun SettingsGroup.persistentBooleanProperty(
+    description: String? = null,
+    value: KMutableProperty0<Boolean>,
+    name: String? = null,
+    init: SimplePersistentBooleanProperty.() -> Unit = {}
+): PersistentValueProperty<Boolean> =
+    SimplePersistentBooleanProperty(
+        SimplePersistentValueProperty(
+            SimpleValueProperty(name, description, value, this),
+            transformerOf(String::toBoolean, Boolean::toString)
+        )
+    ).also { it.init(); add(it) }
+
+fun <R : Any> SettingsGroup.persistentChoiceProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<R>,
+    transformer: Transformer<R, String>,
+    init: ChoiceProperty<R, String>.() -> Unit = {}
+): ChoiceProperty<R, String> =
+    PersistentChoiceProperty(
+        SimpleValueProperty(name, description, value, this),
+        transformer
+    ).also { it.init(); add(it) }
+
+fun SettingsGroup.persistentChoiceProperty(
+    name: String? = null,
+    description: String? = null,
+    value: KMutableProperty0<String>,
+    init: ChoiceProperty<String, String>.() -> Unit = {}
+): ChoiceProperty<String, String> = choiceProperty(name, description, value, init)
+

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Transformer.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Transformer.kt
@@ -1,6 +1,5 @@
 package com.github.weisj.darkmode.platform.settings
 
-import com.intellij.util.castSafelyTo
 
 /**
  * Transformer for changing the outwards type of a property.

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Transformer.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Transformer.kt
@@ -1,8 +1,36 @@
 package com.github.weisj.darkmode.platform.settings
 
-class Transformer<R, T>(
-    val write: (T) -> R,
-    val read: (R) -> T
-)
+import com.intellij.util.castSafelyTo
 
-fun <T> constantTransformer(): Transformer<T, T> = Transformer({ t -> t }, { t -> t })
+/**
+ * Transformer for changing the outwards type of a property.
+ * R is the real type and T the transformed type.
+ */
+interface Transformer<R, T> {
+    val write: (T) -> R
+    val read: (R) -> T
+}
+
+class DefaultTransformer<R, T>(
+    override val write: (T) -> R,
+    override val read: (R) -> T
+) : Transformer<R, T>
+
+infix fun <R, T, S> Transformer<R, T>.andThen(other: Transformer<T, S>): Transformer<R, S> {
+    return transformerOf(other.write andThen write, read andThen other.read)
+}
+
+fun <R, T> Transformer<R, T?>.readFallback(fallback: T): Transformer<R, T> {
+    return this andThen transformerOf({ t -> t }, { t -> t ?: fallback })
+}
+
+fun <R, T> Transformer<R?, T>.writeFallback(fallback: R): Transformer<R, T> {
+    return transformerOf<R, R?>({ t -> t ?: fallback }, { t -> t }) andThen this
+}
+
+object IdentityTransformer : Transformer<Any, Any> by DefaultTransformer({ t -> t }, { t -> t })
+
+inline fun <reified T : Any> identityTransformer(): Transformer<T, T> =
+    IdentityTransformer.castSafelyTo<Transformer<T, T>>()!!
+
+fun <R, T> transformerOf(write: (T) -> R, read: (R) -> T) = DefaultTransformer(write, read)

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Transformer.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Transformer.kt
@@ -1,0 +1,8 @@
+package com.github.weisj.darkmode.platform.settings
+
+class Transformer<R, T>(
+    val write: (T) -> R,
+    val read: (R) -> T
+)
+
+fun <T> constantTransformer(): Transformer<T, T> = Transformer({ t -> t }, { t -> t })

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Util.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Util.kt
@@ -1,5 +1,7 @@
 package com.github.weisj.darkmode.platform.settings
 
+inline fun <reified T> Any.castSafelyTo() : T? = (this as? T)
+
 fun String.toPair(delimiter: Char): Pair<String, String>? = split(delimiter, limit = 2).let {
     if (it.size == 2) it[0] to it[1] else null
 }

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Util.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Util.kt
@@ -1,0 +1,5 @@
+package com.github.weisj.darkmode.platform.settings
+
+fun String.toPair(delimiter: Char): Pair<String, String>? = split(delimiter, limit = 2).let {
+    if (it.size == 2) it[0] to it[1] else null
+}

--- a/base/src/main/java/com/github/weisj/darkmode/platform/settings/Util.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/settings/Util.kt
@@ -3,3 +3,9 @@ package com.github.weisj.darkmode.platform.settings
 fun String.toPair(delimiter: Char): Pair<String, String>? = split(delimiter, limit = 2).let {
     if (it.size == 2) it[0] to it[1] else null
 }
+
+infix fun <R, T, S> ((R) -> T).andThen(g: (T) -> S): (R) -> S {
+    return { r -> g(this(r)) }
+}
+
+fun <R, T>((R) -> T).or(fallback : T) : (R?) -> T = {r -> r?.let { this(r) }?:fallback }

--- a/dependencies-bom/build.gradle.kts
+++ b/dependencies-bom/build.gradle.kts
@@ -31,5 +31,7 @@ dependencies {
         // dependency on it during compilation.
         apiv("com.github.weisj:darklaf-native-utils", "darklaf")
         apiv("com.jetbrains.intellij.platform:util", "idea")
+        apiv("com.google.auto.service:auto-service-annotations", "auto-service")
+        apiv("com.google.auto.service:auto-service", "auto-service")
     }
 }

--- a/dependencies-bom/build.gradle.kts
+++ b/dependencies-bom/build.gradle.kts
@@ -13,14 +13,12 @@ val String.v: String get() = rootProject.extra["$this.version"] as String
 fun DependencyConstraintHandlerScope.apiv(
     notation: String,
     versionProp: String = notation.substringAfterLast(':')
-) =
-    "api"(notation + ":" + versionProp.v)
+) = "api"("$notation:${versionProp.v}")
 
 fun DependencyConstraintHandlerScope.runtimev(
     notation: String,
     versionProp: String = notation.substringAfterLast(':')
-) =
-    "runtime"(notation + ":" + versionProp.v)
+) = "runtimeOnly"("$notation:${versionProp.v}")
 
 dependencies {
     // Parenthesis are needed here: https://github.com/gradle/gradle/issues/9248

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ darklaf.version                                           = 2.3.0
 auto-service.version                                      = 1.0-rc7
 
 # These versions must always stay in sync with another.
-idea.version                                              = [201,)
+idea.version                                              = [201,202)
 ideaPlugin.version                                        = 2020.1
 ideaPlugin.since.version                                  = 201
 ideaPlugin.until.version                                  = 201.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ kotlin.version                                            = 1.3.72
 
 # Dependencies
 darklaf.version                                           = 2.3.0
-auto-service.version                                      = 1.0-rc5
+auto-service.version                                      = 1.0-rc7
 
 # These versions must always stay in sync with another.
 idea.version                                              = [201,)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+# suppress inspection "UnusedProperty" for whole file
 # Gradle
 org.gradle.parallel                                       = true
 kotlin.code.style                                         = official
@@ -22,5 +23,5 @@ auto-service.version                                      = 1.0-rc7
 # These versions must always stay in sync with another.
 idea.version                                              = [201,)
 ideaPlugin.version                                        = 2020.1
-ideaPlugin.since.version                                   = 201
+ideaPlugin.since.version                                  = 201
 ideaPlugin.until.version                                  = 201.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ kotlin.version                                            = 1.3.72
 
 # Dependencies
 darklaf.version                                           = 2.3.0
+auto-service.version                                      = 1.0-rc5
 
 # These versions must always stay in sync with another.
 idea.version                                              = [201,)

--- a/linux/gnome/build.gradle.kts
+++ b/linux/gnome/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `uber-jni-jar`
     `use-prebuilt-binaries`
     kotlin("jvm")
+    kotlin("kapt")
 }
 
 library {
@@ -21,20 +22,38 @@ library {
             compileTasks.configureEach {
                 compilerArgs.addAll(toolChain.map {
                     when (it) {
-                        // These parameters (excluding --std=c++11) were obtained with `pkg-config --cflags glibmm-2.4 giomm-2.4 sigc++-2.0`.
+                        // These parameters (excluding --std=c++11) were obtained with `pkg-config --cflags glibmm-2.4 giomm-2.4 sigc++-2.0 gtk+-3.0`.
                         is Gcc, is Clang -> listOf(
                             "--std=c++11",
                             "-pthread",
                             "-I/usr/include/giomm-2.4",
                             "-I/usr/lib/x86_64-linux-gnu/giomm-2.4/include",
-                            "-I/usr/include/libmount",
-                            "-I/usr/include/blkid",
                             "-I/usr/include/glibmm-2.4",
                             "-I/usr/lib/x86_64-linux-gnu/glibmm-2.4/include",
-                            "-I/usr/include/glib-2.0",
-                            "-I/usr/lib/x86_64-linux-gnu/glib-2.0/include",
                             "-I/usr/include/sigc++-2.0",
-                            "-I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include"
+                            "-I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include",
+                            "-I/usr/include/gtk-3.0",
+                            "-I/usr/include/at-spi2-atk/2.0",
+                            "-I/usr/include/at-spi-2.0",
+                            "-I/usr/include/dbus-1.0",
+                            "-I/usr/lib/x86_64-linux-gnu/dbus-1.0/include",
+                            "-I/usr/include/gtk-3.0",
+                            "-I/usr/include/gio-unix-2.0",
+                            "-I/usr/include/cairo",
+                            "-I/usr/include/pango-1.0",
+                            "-I/usr/include/fribidi",
+                            "-I/usr/include/harfbuzz",
+                            "-I/usr/include/atk-1.0",
+                            "-I/usr/include/cairo",
+                            "-I/usr/include/pixman-1",
+                            "-I/usr/include/uuid",
+                            "-I/usr/include/freetype2",
+                            "-I/usr/include/libpng16",
+                            "-I/usr/include/gdk-pixbuf-2.0",
+                            "-I/usr/include/libmount",
+                            "-I/usr/include/blkid",
+                            "-I/usr/include/glib-2.0",
+                            "-I/usr/lib/x86_64-linux-gnu/glib-2.0/include"
                         )
                         else -> emptyList()
                     }
@@ -51,14 +70,23 @@ library {
             linkTask.configure {
                 linkerArgs.addAll(toolChain.map {
                     when (it) {
-                        // These parameters were obtained with `pkg-config --libs glibmm-2.4 giomm-2.4 sigc++-2.0`.
+                        // These parameters were obtained with `pkg-config --libs glibmm-2.4 giomm-2.4 sigc++-2.0 gtk+-3.0`.
                         is Gcc, is Clang -> listOf(
                             "-lgiomm-2.4",
-                            "-lgio-2.0",
                             "-lglibmm-2.4",
+                            "-lsigc-2.0",
+                            "-lgtk-3",
+                            "-lgdk-3",
+                            "-lpangocairo-1.0",
+                            "-lpango-1.0",
+                            "-lharfbuzz",
+                            "-latk-1.0",
+                            "-lcairo-gobject",
+                            "-lcairo",
+                            "-lgdk_pixbuf-2.0",
+                            "-lgio-2.0",
                             "-lgobject-2.0",
-                            "-lglib-2.0",
-                            "-lsigc-2.0"
+                            "-lglib-2.0"
                         )
                         else -> emptyList()
                     }
@@ -70,4 +98,7 @@ library {
 
 dependencies {
     compileOnly(kotlin("stdlib-jdk8"))
+    kapt(platform(project(":auto-dark-mode-dependencies-bom")))
+    kapt("com.google.auto.service:auto-service")
+    compileOnly("com.google.auto.service:auto-service-annotations")
 }

--- a/linux/gnome/pre-build-libraries/linux-x86-64/library.md
+++ b/linux/gnome/pre-build-libraries/linux-x86-64/library.md
@@ -1,0 +1,3 @@
+If your machine can't build the linux-gnome library and no version could 
+be downloaded from the repository, manually download the latest
+'linux-gnome-x86-64.zip' from the repository and place the unpacked library in this folder.

--- a/linux/gnome/src/main/cpp/DarkModeGnome.cpp
+++ b/linux/gnome/src/main/cpp/DarkModeGnome.cpp
@@ -23,6 +23,7 @@
  *
  */
 #include "com_github_weisj_darkmode_platform_linux_gnome_GnomeNative.h"
+#include "GioUtils.hpp"
 
 #include <string>
 #include <glibmm-2.4/glibmm.h>
@@ -104,6 +105,6 @@ Java_com_github_weisj_darkmode_platform_linux_gnome_GnomeNative_deleteEventHandl
 
 JNIEXPORT void JNICALL
 Java_com_github_weisj_darkmode_platform_linux_gnome_GnomeNative_init(JNIEnv *env, jclass obj) {
-    Gio::init();
+    ensure_gio_init();
     settings = Gio::Settings::create(SETTINGS_SCHEMA_NAME);
 }

--- a/linux/gnome/src/main/cpp/GioUtils.cpp
+++ b/linux/gnome/src/main/cpp/GioUtils.cpp
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#include "GioUtils.hpp"
+
+#include <giomm-2.4/giomm.h>
+
+bool gioAlreadyInit = false;
+
+void ensure_gio_init() {
+    if (!gioAlreadyInit) {
+        Gio::init();
+        gioAlreadyInit = true;
+    }
+}

--- a/linux/gnome/src/main/cpp/GnomeThemeUtils.cpp
+++ b/linux/gnome/src/main/cpp/GnomeThemeUtils.cpp
@@ -1,0 +1,153 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#include "com_github_weisj_darkmode_platform_linux_gnome_GnomeThemeUtils.h"
+#include "GioUtils.hpp"
+
+#include <glibmm-2.4/glibmm.h>
+#include <giomm-2.4/giomm.h>
+#include <gtk/gtk.h>
+#include <utility>
+
+/**
+ * Get all the directories of the system for a resource.
+ * @param resource The resource to get the directories.
+ * @returns An array of paths.
+ */
+std::vector<std::string> get_resources_dirs_paths(const std::string &resource) {
+    std::vector < std::string > first_two_paths;
+
+    first_two_paths.push_back(Glib::build_filename(Glib::get_home_dir(), "." + resource));
+    first_two_paths.push_back(Glib::build_filename(Glib::get_user_data_dir(), resource));
+
+    std::vector < std::string > system_data_dirs = Glib::get_system_data_dirs();
+    std::vector < std::string > system_data_dirs_processed;
+    system_data_dirs_processed.resize(system_data_dirs.size());
+    std::transform(system_data_dirs.begin(), system_data_dirs.end(), system_data_dirs_processed.begin(),
+            [&](const std::string &i) {
+                return Glib::build_filename(i, resource);
+            });
+
+    std::vector < std::string > paths(first_two_paths);
+    paths.insert(paths.end(), system_data_dirs_processed.begin(), system_data_dirs_processed.end());
+
+    return paths;
+}
+
+void get_resources_for_path(const std::string &path, std::vector<std::map<std::string, std::string>> &out) {
+    Glib::RefPtr < Gio::File > resources_dir = Gio::File::create_for_path(path);
+
+    if (resources_dir->query_file_type(Gio::FileQueryInfoFlags::FILE_QUERY_INFO_NONE) != Gio::FileType::FILE_TYPE_DIRECTORY) {
+        return;
+    }
+
+    Glib::RefPtr < Gio::FileEnumerator > resources_dirs_enumerator = resources_dir->enumerate_children("",
+            Gio::FileQueryInfoFlags::FILE_QUERY_INFO_NONE);
+
+    while (true) {
+        Glib::RefPtr < Gio::FileInfo > resource_dir_info = resources_dirs_enumerator->next_file();
+
+        if (!resource_dir_info) {
+            break;
+        }
+
+        Glib::RefPtr < Gio::File > resource_dir = resources_dirs_enumerator->get_child(resource_dir_info);
+
+        if (!resource_dir) {
+            break;
+        }
+        std::map < std::string, std::string > resource;
+        resource.insert(std::pair<std::string, std::string>("name", resource_dir->get_basename()));
+        resource.insert(std::pair<std::string, std::string>("path", resource_dir->get_path()));
+        out.push_back(resource);
+    }
+    resources_dirs_enumerator->close();
+}
+
+/**
+ * Get all the resources installed on the system of a certain type.
+ * @param type The resources to get.
+ * @returns A set of installed resources.
+ */
+std::vector<std::map<std::string, std::string>> get_installed_resources(const std::string &type) {
+    std::vector<std::map<std::string, std::string>> installed_resources;
+    std::vector < std::string > resources_dirs_paths = get_resources_dirs_paths(type);
+    std::for_each(resources_dirs_paths.begin(), resources_dirs_paths.end(), [&](const std::string &i) {
+        return get_resources_for_path(i, installed_resources);
+    });
+    return installed_resources;
+}
+
+bool gtk_3_css_exists(unsigned int gtk_version, std::map<std::string, std::string> &theme) {
+    if (gtk_version % 2) {
+        gtk_version += 1;
+    }
+    std::string full_gtk_version = "gtk-3." + std::to_string(gtk_version);
+    Glib::RefPtr < Gio::File > css_file = Gio::File::create_for_path(
+            Glib::build_filename(theme["path"], full_gtk_version, "gtk.css"));
+    return css_file->query_exists();
+}
+
+void verify_css_for_theme(std::map<std::string, std::string> theme, std::vector<std::string> &out) {
+    std::vector<unsigned int> v { 0, gtk_get_minor_version() };
+    bool version = std::any_of(v.begin(), v.end(), [&](unsigned int i) {
+        return gtk_3_css_exists(i, theme);
+    });
+    if (version) {
+        out.push_back(theme["name"]);
+    }
+}
+
+/**
+ * Get all the installed GTK themes on the system.
+ * @returns A set containing all the installed GTK themes names.
+ */
+std::vector<std::string> get_installed_gtk_themes() {
+    ensure_gio_init();
+    //These themes come by default
+    std::vector < std::string > themes( { "Adwaita", "HighContrast", "HighContrastInverse" });
+    std::vector<std::map<std::string, std::string>> installed_resources = get_installed_resources("themes");
+    std::for_each(installed_resources.begin(), installed_resources.end(), [&](std::map<std::string, std::string> i) {
+        return verify_css_for_theme(std::move(i), themes);
+    });
+    return themes;
+}
+
+JNIEXPORT jobject JNICALL Java_com_github_weisj_darkmode_platform_linux_gnome_GnomeThemeUtils_getInstalledThemes(
+        JNIEnv *env, jclass) {
+    std::vector < std::string > vector = get_installed_gtk_themes();
+    jclass java_util_ArrayList = static_cast<jclass>(env->NewGlobalRef(env->FindClass("java/util/ArrayList")));
+    jmethodID java_util_ArrayList_ = env->GetMethodID(java_util_ArrayList, "<init>", "(I)V");
+    jmethodID java_util_ArrayList_size = env->GetMethodID(java_util_ArrayList, "size", "()I");
+    jmethodID java_util_ArrayList_get = env->GetMethodID(java_util_ArrayList, "get", "(I)Ljava/lang/Object;");
+    jmethodID java_util_ArrayList_add = env->GetMethodID(java_util_ArrayList, "add", "(Ljava/lang/Object;)Z");
+
+    jobject result = env->NewObject(java_util_ArrayList, java_util_ArrayList_, vector.size());
+    for (std::string s : vector) {
+        jstring element = env->NewStringUTF(s.c_str());
+        env->CallBooleanMethod(result, java_util_ArrayList_add, element);
+        env->DeleteLocalRef(element);
+    }
+    return result;
+}

--- a/linux/gnome/src/main/headers/GioUtils.hpp
+++ b/linux/gnome/src/main/headers/GioUtils.hpp
@@ -1,0 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#pragma once
+
+void ensure_gio_init();

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeLibrary.java
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeLibrary.java
@@ -24,12 +24,11 @@
  */
 package com.github.weisj.darkmode.platform.linux.gnome;
 
-import java.util.logging.Logger;
-
-import com.github.weisj.darklaf.platform.AbstractLibrary;
+import com.github.weisj.darkmode.platform.AbstractPluginLibrary;
 import com.github.weisj.darkmode.platform.LibraryUtil;
+import com.github.weisj.darkmode.platform.PluginLogger;
 
-public class GnomeLibrary extends AbstractLibrary {
+public class GnomeLibrary extends AbstractPluginLibrary {
 
     private static final String PROJECT_NAME = "auto-dark-mode-linux-gnome";
     private static final String PATH = "/com/github/weisj/darkmode/" + PROJECT_NAME + "/linux-x86-64/";
@@ -37,7 +36,7 @@ public class GnomeLibrary extends AbstractLibrary {
     private static final GnomeLibrary instance = new GnomeLibrary();
 
     protected GnomeLibrary() {
-        super(PATH, DLL_NAME, Logger.getLogger(GnomeLibrary.class.getName()));
+        super(PATH, DLL_NAME, PluginLogger.getLogger(GnomeLibrary.class));
     }
 
     static GnomeLibrary get() {

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
@@ -1,0 +1,95 @@
+package com.github.weisj.darkmode.platform.linux.gnome
+
+import com.github.weisj.darkmode.platform.LibraryUtil
+import com.github.weisj.darkmode.platform.settings.*
+import com.google.auto.service.AutoService
+
+@AutoService(SettingsContainerProvider::class)
+class GnomeSettingsProvider : SingletonSettingsContainerProvider({ GnomeSettings }, enabled = LibraryUtil.isGnome)
+
+data class GtkTheme(val name: String) : Comparable<GtkTheme> {
+    override fun compareTo(other: GtkTheme): Int = name.compareTo(other.name)
+}
+
+object GnomeSettings : DefaultSettingsContainer() {
+
+    /**
+     * This enum holds default values for the light, dark, and high contrast GTK themes.
+     * The defaults are a safe bet as they are included with almost any install of GTK.
+     * Even if they're not present, the way the logic works in GnomeThemeMonitorService,
+     * there won't be an issue and the plugin will fall back on the light theme.
+     *
+     * **See:** [Arch Wiki on GTK](https://wiki.archlinux.org/index.php/GTK#Themes)
+     */
+    private enum class DefaultGtkTheme(val info: GtkTheme) {
+        DARK(GtkTheme("Adwaita-dark")),
+        LIGHT(GtkTheme("Adwaita")),
+        HIGH_CONTRAST(GtkTheme("HighContrast")),
+    }
+
+    private const val DEFAULT_GUESS_LIGHT_AND_DARK_THEMES = true
+
+    @JvmField
+    var darkGtkTheme = DefaultGtkTheme.DARK.info
+
+    @JvmField
+    var lightGtkTheme = DefaultGtkTheme.LIGHT.info
+
+    @JvmField
+    var highContrastGtkTheme = DefaultGtkTheme.HIGH_CONTRAST.info
+
+    @JvmField
+    var guessLightAndDarkThemes = DEFAULT_GUESS_LIGHT_AND_DARK_THEMES
+
+    init {
+        if (!GnomeLibrary.get().isLoaded) {
+            throw IllegalStateException("Gnome library not loaded.")
+        }
+        group("Gnome Theme") {
+            val installedThemes = GnomeThemeUtils.getInstalledThemes()
+            /*
+             * The default themes are added to this list. They would already be added to the list because of their
+             * presence when initializing the `themes` vector in GnomeThemeUtils.cpp but because they are not
+             * the same instance as the defaults, the dropdown list would default to random themes because
+             * the instances of the three defaults couldn't be found in ChoiceProperty#choices.
+             * For this reason, the default themes that the native code adds to this list are overwritten
+             * with the instances created inside the enum constructors of DefaultGtkTheme.
+             */
+            val installedGtkThemes =
+                mutableSetOf(DefaultGtkTheme.DARK.info, DefaultGtkTheme.LIGHT.info, DefaultGtkTheme.HIGH_CONTRAST.info)
+                    .apply { addAll(installedThemes.map { GtkTheme(it) }) }
+                    .toList()
+                    .sorted()
+            val gtkThemeRenderer = GtkTheme::name
+            val gtkThemeTransformer = transformerOf(write = ::parseGtkTheme, read = ::readGtkTheme.or(""))
+
+            persistentBooleanProperty(
+                description = "Guess light/dark theme based on name",
+                value = ::guessLightAndDarkThemes
+            ) {
+                inverted()
+                control(withProperty(::lightGtkTheme), withProperty(::darkGtkTheme), withProperty(::highContrastGtkTheme))
+            }
+
+            persistentChoiceProperty(
+                description = "Light GTK Theme",
+                value = ::lightGtkTheme,
+                transformer = gtkThemeTransformer.writeFallback(DefaultGtkTheme.LIGHT.info)
+            ) { choices = installedGtkThemes; renderer = gtkThemeRenderer }
+            persistentChoiceProperty(
+                description = "Dark GTK Theme",
+                value = ::darkGtkTheme,
+                transformer = gtkThemeTransformer.writeFallback(DefaultGtkTheme.DARK.info)
+            ) { choices = installedGtkThemes; renderer = gtkThemeRenderer }
+            persistentChoiceProperty(
+                description = "High Contrast GTK Theme",
+                value = ::highContrastGtkTheme,
+                transformer = gtkThemeTransformer.writeFallback(DefaultGtkTheme.HIGH_CONTRAST.info)
+            ) { choices = installedGtkThemes; renderer = gtkThemeRenderer }
+        }
+    }
+
+    private fun readGtkTheme(info: GtkTheme): String = info.name
+
+    private fun parseGtkTheme(name: String): GtkTheme? = GtkTheme(name)
+}

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
@@ -104,8 +104,8 @@ object GnomeSettings : DefaultSettingsContainer() {
         if (!guessingMechanismInfoLogged) {
             Notifications.dispatchNotification(
                 """
-                Auto Dark Mode is currently guessing the whether the current Gnome theme
-                is dark or light. You can explicitly specify which theme is your light/dark/high-contrast theme
+                Auto Dark Mode is currently guessing whether the current Gnome theme
+                is dark or light. You can explicitly specify your light/dark/high-contrast themes
                 in "File | Settings | Auto Dark Mode" for better results.
                 """.trimIndent()
             )

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
@@ -105,9 +105,10 @@ object GnomeSettings : DefaultSettingsContainer() {
             Notifications.dispatchNotification(
                 """
                 Auto Dark Mode is currently guessing whether the current Gnome theme
-                is dark or light. You can explicitly specify your light/dark/high-contrast themes
-                in "File | Settings | Auto Dark Mode" for better results.
-                """.trimIndent()
+                is dark or light. You can explicitly specify your light, dark and high-contrast
+                theme in <nobr>"File | Settings | Auto Dark Mode"</nobr> for better results.
+                """.trimIndent(),
+                showSettingsLink = true
             )
             guessingMechanismInfoLogged = true
         }

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
@@ -106,7 +106,7 @@ object GnomeSettings : DefaultSettingsContainer() {
                 """
                 Auto Dark Mode is currently guessing the whether the current Gnome theme
                 is dark or light. You can explicitly specify which theme is your light/dark/high-contrast theme
-                in the settings for better results.
+                in "File | Settings | Auto Dark Mode" for better results.
                 """.trimIndent()
             )
             guessingMechanismInfoLogged = true

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeSettings.kt
@@ -1,6 +1,7 @@
 package com.github.weisj.darkmode.platform.linux.gnome
 
 import com.github.weisj.darkmode.platform.LibraryUtil
+import com.github.weisj.darkmode.platform.Notifications
 import com.github.weisj.darkmode.platform.settings.*
 import com.google.auto.service.AutoService
 
@@ -40,6 +41,12 @@ object GnomeSettings : DefaultSettingsContainer() {
 
     @JvmField
     var guessLightAndDarkThemes = DEFAULT_GUESS_LIGHT_AND_DARK_THEMES
+
+    /*
+     * Ensures the information about the guessing mechanism is only logged
+     * once.
+     */
+    private var guessingMechanismInfoLogged = false
 
     init {
         if (!GnomeLibrary.get().isLoaded) {
@@ -86,6 +93,23 @@ object GnomeSettings : DefaultSettingsContainer() {
                 value = ::highContrastGtkTheme,
                 transformer = gtkThemeTransformer.writeFallback(DefaultGtkTheme.HIGH_CONTRAST.info)
             ) { choices = installedGtkThemes; renderer = gtkThemeRenderer }
+        }
+
+        hidden {
+            persistentBooleanProperty(value = ::guessingMechanismInfoLogged)
+        }
+    }
+
+    override fun onSettingsLoaded() {
+        if (!guessingMechanismInfoLogged) {
+            Notifications.dispatchNotification(
+                """
+                Auto Dark Mode is currently guessing the whether the current Gnome theme
+                is dark or light. You can explicitly specify which theme is your light/dark/high-contrast theme
+                in the settings for better results.
+                """.trimIndent()
+            )
+            guessingMechanismInfoLogged = true
         }
     }
 

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeThemeMonitorService.java
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeThemeMonitorService.java
@@ -30,17 +30,21 @@ public class GnomeThemeMonitorService implements ThemeMonitorService {
 
     @Override
     public boolean isDarkThemeEnabled() {
-        // TODO: Stop guessing and check the settings when available (like what is mentioned in the GtkVariants class)
         String currentTheme = GnomeNative.getCurrentTheme();
-        return currentTheme.equals(GtkVariants.guessFrom(currentTheme).get(GtkVariants.Variant.Night));
+        if (GnomeSettings.guessLightAndDarkThemes) {
+            return currentTheme.equals(GtkVariants.guessFrom(currentTheme).get(GtkVariants.Variant.Night));
+        } else {
+            return GnomeSettings.darkGtkTheme.getName().equals(currentTheme);
+        }
     }
 
     @Override
     public boolean isHighContrastEnabled() {
-        // TODO: This right now isn't exactly doable with the guessing implementation. It requires a user-accessible
-        // place to
-        // set which theme is their "high contrast theme"
-        return false;
+        if (GnomeSettings.guessLightAndDarkThemes) {
+            return false;
+        }
+        String currentTheme = GnomeNative.getCurrentTheme();
+        return GnomeSettings.highContrastGtkTheme.getName().equals(currentTheme);
     }
 
     @Override

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeThemeUtils.java
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GnomeThemeUtils.java
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+package com.github.weisj.darkmode.platform.linux.gnome;
+
+import java.util.ArrayList;
+
+public class GnomeThemeUtils {
+    /**
+     * @return a list of the currently installed GTK themes.
+     */
+    static native ArrayList<String> getInstalledThemes();
+}

--- a/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GtkVariants.kt
+++ b/linux/gnome/src/main/java/com/github/weisj/darkmode/platform/linux/gnome/GtkVariants.kt
@@ -29,11 +29,9 @@ import java.util.EnumMap
 /**
  * This class is effectively a conversion of the GtkVariants.js module seen [here](https://gitlab.com/rmnvgr/nightthemeswitcher-gnome-shell-extension/-/blob/0d32907de1d004a6a92f02b8e0b79302340e5244/src/modules/GtkVariants.js).
  *
- * This class should only be used as a temporary solution until settings are implemented which allow the user to
- * denote which of their themes they consider to be their light and dark themes. This settings should be applicable to
- * all distributions (not just ones using Gnome) as most distributions have different themes which provide a dark and
- * light variant. Very few distributions will simply have a "dark *mode*" and a "light *mode*" like Windows
- * and Mac OS.
+ * The logic of guessFrom will be used if the user chooses to have the plugin guess which of their themes is their
+ * light and dark theme (guessing is enabled by default).
+ * @see GnomeSettings.guessLightAndDarkThemes
  */
 object GtkVariants {
     /**
@@ -88,7 +86,7 @@ object GtkVariants {
             themeName.contains("Flat-Remix-GTK") -> {
                 val isSolid = themeName.contains("-Solid")
                 val withoutBorder = themeName.contains("-NoBorder")
-                val basename = themeName.split(Regex("-")).slice(IntRange(0,3)).joinToString(separator = "-")
+                val basename = themeName.split(Regex("-")).slice(IntRange(0, 3)).joinToString(separator = "-")
                 variants[Variant.Day] =
                     basename + (if (themeName.contains("-Darker")) "-Darker" else "") + if (isSolid) "-Solid" else ""
                 variants[Variant.Night] =

--- a/macos/build.gradle.kts
+++ b/macos/build.gradle.kts
@@ -14,9 +14,8 @@ library {
 
     dependencies {
         jvmImplementation(project(":auto-dark-mode-base"))
-        jvmImplementation("com.github.weisj:darklaf-native-utils")
         nativeImplementation("dev.nokee.framework:JavaVM:$frameworkVersion")
-        nativeImplementation("dev.nokee.framework:JavaVM:$frameworkVersion") {
+        nativeImplementation("dLoev.nokee.framework:JavaVM:$frameworkVersion") {
             capabilities {
                 requireCapability("JavaVM:JavaNativeFoundation:$frameworkVersion")
             }

--- a/macos/build.gradle.kts
+++ b/macos/build.gradle.kts
@@ -15,7 +15,7 @@ library {
     dependencies {
         jvmImplementation(project(":auto-dark-mode-base"))
         nativeImplementation("dev.nokee.framework:JavaVM:$frameworkVersion")
-        nativeImplementation("dLoev.nokee.framework:JavaVM:$frameworkVersion") {
+        nativeImplementation("dev.nokee.framework:JavaVM:$frameworkVersion") {
             capabilities {
                 requireCapability("JavaVM:JavaNativeFoundation:$frameworkVersion")
             }

--- a/macos/pre-build-libraries/macos-x86-64/library.md
+++ b/macos/pre-build-libraries/macos-x86-64/library.md
@@ -1,2 +1,3 @@
-If your machine can't build the macos library download the latest
-'libauto-dark-mode-macos.dylib' from the repository and place it in this folder.
+If your machine can't build the macos library  and no version could 
+be downloaded from the repository, manually download the latest
+'macos-x86-64.zip' from the repository and place the unpacked library in this folder.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -12,14 +12,14 @@ plugins {
 }
 
 val String.v: String get() = rootProject.extra["$this.version"] as String
-val isPublished by props()
+val isPublished by props(true)
 val intellijPublishToken: String by props("")
 
 intellij {
     version = "ideaPlugin".v
 }
 
-tasks.getByName<PatchPluginXmlTask>("patchPluginXml") {
+tasks.withType<PatchPluginXmlTask> {
     changeNotes(
         """
         <ul>
@@ -37,8 +37,9 @@ dependencies {
     implementation(project(":auto-dark-mode-macos"))
     implementation(project(":auto-dark-mode-linux"))
 
-    compileOnly("com.google.auto.service:auto-service")
-    kapt("com.google.auto.service:auto-service:1.0-rc5")
+    kapt(platform(project(":auto-dark-mode-dependencies-bom")))
+    kapt("com.google.auto.service:auto-service")
+    compileOnly("com.google.auto.service:auto-service-annotations")
 }
 
 tasks.withType<PublishTask> {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("org.jetbrains.intellij")
     id("com.github.vlsi.gradle-extensions")
     kotlin("jvm")
+    kotlin("kapt")
 }
 
 val String.v: String get() = rootProject.extra["$this.version"] as String
@@ -35,6 +36,9 @@ dependencies {
     implementation(project(":auto-dark-mode-windows"))
     implementation(project(":auto-dark-mode-macos"))
     implementation(project(":auto-dark-mode-linux"))
+
+    compileOnly("com.google.auto.service:auto-service")
+    kapt("com.google.auto.service:auto-service:1.0-rc5")
 }
 
 tasks.withType<PublishTask> {

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,1 +1,0 @@
-isPublished = true

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
@@ -17,8 +17,7 @@ import javax.swing.UIManager.LookAndFeelInfo
  */
 class AutoDarkMode : Disposable, ThemeCallback {
     private val alarm = Alarm()
-    private val options: AutoDarkModeOptions = ServiceManager.getService(AutoDarkModeOptions::class.java)
-    private val monitor: Lazy<ThemeMonitor> = lazy { createMonitor() }
+    private val monitor = lazy { createMonitor() }
 
     private fun createMonitor(): ThemeMonitor {
         return try {
@@ -54,10 +53,14 @@ class AutoDarkMode : Disposable, ThemeCallback {
     }
 
     private fun getTargetLaf(dark: Boolean, highContrast: Boolean): Pair<LookAndFeelInfo, EditorColorsScheme> {
-        return when {
-            highContrast && options.checkHighContrast -> Pair(options.highContrastTheme, options.highContrastCodeScheme)
-            dark -> Pair(options.darkTheme, options.darkCodeScheme)
-            else -> Pair(options.lightTheme, options.lightCodeScheme)
+        return GeneralThemeSettings.run {
+            when {
+                highContrast && checkHighContrast -> {
+                    Pair(highContrastTheme, highContrastCodeScheme)
+                }
+                dark -> Pair(darkTheme, darkCodeScheme)
+                else -> Pair(lightTheme, lightCodeScheme)
+            }
         }
     }
 
@@ -95,5 +98,6 @@ class AutoDarkMode : Disposable, ThemeCallback {
 
     companion object {
         private val LOGGER = Logger.getInstance(AutoDarkMode::class.java)
+        private val OPTIONS = ServiceManager.getService(AutoDarkModeOptions::class.java)
     }
 }

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
@@ -97,7 +97,7 @@ class AutoDarkMode : Disposable, ThemeCallback {
     }
 
     companion object {
-        private val LOGGER = Logger.getInstance(AutoDarkMode::class.java)
+        private val LOGGER = PluginLogger.getLogger(AutoDarkMode::class.java)
         private val OPTIONS = ServiceManager.getService(AutoDarkModeOptions::class.java)
     }
 }

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
@@ -29,7 +29,6 @@ class AutoDarkMode : Disposable, ThemeCallback {
     }
 
     fun start() {
-        Notifications.dispatchNotification("test", NotificationType.ERROR)
         monitor.value.isRunning = true
     }
 

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkMode.kt
@@ -5,7 +5,6 @@ import com.intellij.ide.actions.QuickChangeLookAndFeel
 import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.ServiceManager
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.util.registry.Registry
@@ -30,6 +29,7 @@ class AutoDarkMode : Disposable, ThemeCallback {
     }
 
     fun start() {
+        Notifications.dispatchNotification("test", NotificationType.ERROR)
         monitor.value.isRunning = true
     }
 
@@ -99,5 +99,9 @@ class AutoDarkMode : Disposable, ThemeCallback {
     companion object {
         private val LOGGER = PluginLogger.getLogger(AutoDarkMode::class.java)
         private val OPTIONS = ServiceManager.getService(AutoDarkModeOptions::class.java)
+
+        init {
+            OPTIONS.settingsLoaded()
+        }
     }
 }

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
@@ -58,10 +58,23 @@ class AutoDarkModeOptions : PersistentStateComponent<AutoDarkModeOptions.State> 
     }
 
     override fun loadState(toLoad: State) {
-        toLoad.entries.forEach { properties[it.key]?.value = it.value }
+        toLoad.entries.forEach {
+            properties.getOrPut(it.key, { PersistentValuePropertyStub(it.key, it.value) }).value = it.value
+        }
     }
 
     data class State(var entries: MutableList<Entry> = mutableListOf())
 
-    data class Entry(var key : String = "", var value : String = "")
+    data class Entry(var key: String = "", var value: String = "")
+
+    private class PersistentValuePropertyStub(
+        override val name: String,
+        override var value: String,
+        override val description: String = "",
+        override var active: Boolean = true
+    ) : PersistentValueProperty<Any>, Observable<ValueProperty<*>> by DefaultObservable() {
+        override var backingValue: Any
+            get() = value
+            set(_) = throw IllegalStateException("Settings value of stub property $name.")
+    }
 }

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
@@ -2,10 +2,7 @@ package com.github.weisj.darkmode
 
 import com.github.weisj.darkmode.platform.ServiceUtil
 import com.github.weisj.darkmode.platform.settings.*
-import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.RoamingType
-import com.intellij.openapi.components.State
-import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.*
 import kotlin.reflect.KMutableProperty0
 
 /**
@@ -17,26 +14,30 @@ import kotlin.reflect.KMutableProperty0
  * Though accessing fields directly through this class is discouraged. Instead use them through the
  * {@link SettingsContainer} that provides them.
  */
-@State(name = "AutoDarkMode2", storages = [Storage("auto-dark-mode2.xml", roamingType = RoamingType.PER_OS)])
+@State(name = "AutoDarkMode", storages = [Storage("autoDarkMode.xml", roamingType = RoamingType.PER_OS)])
 class AutoDarkModeOptions : PersistentStateComponent<AutoDarkModeOptions.State> {
 
-    val properties: MutableMap<String, ValueProperty<Any>> = HashMap()
-    val containers: List<SettingsContainer> = ServiceUtil.load(SettingsContainer::class.java).asSequence().toList()
+    val properties: MutableMap<String, PersistentValueProperty<Any>> = HashMap()
+    val containers: List<SettingsContainer> =
+        ServiceUtil.load(SettingsContainer::class.java).filter(SettingsContainer::isEnabled).asSequence().toList()
 
     init {
-        containers.flatMap { it.allProperties() }.forEach { properties[it.property.name] = it }
+        containers
+            .flatMap { it.allProperties() }
+            .mapNotNull { it.asPersistent() }
+            .forEach { properties[it.name] = it }
     }
 
     inline fun <reified T : Any> getProperty(name: String): KMutableProperty0<T>? {
-        return properties[name]?.property?.withType()
+        return properties[name]?.let { it::backingValue.withType() }
     }
 
     inline fun <reified T : Any> getReadProperty(name: String): KMutableProperty0<T>? {
-        return properties[name]?.property?.withOutType()
+        return properties[name]?.let { it::backingValue.withOutType() }
     }
 
     inline fun <reified T : Any> getWriteProperty(name: String): KMutableProperty0<T>? {
-        return properties[name]?.property?.withInType()
+        return properties[name]?.let { it::backingValue.withInType() }
     }
 
     inline fun <reified T : Any> readOrNull(name: String): T? = getReadProperty<T>(name)?.get()
@@ -46,39 +47,14 @@ class AutoDarkModeOptions : PersistentStateComponent<AutoDarkModeOptions.State> 
     inline fun <reified T : Any> write(name: String, value: T) = getWriteProperty<T>(name)?.set(value)
 
     override fun getState(): State? {
-        return State(
-            properties
-                .mapValues { e -> e.value.property.get().let { e.value.writer(it) } }
-                .map { (k, v) -> Entry(k, v) }
-                .toTypedArray()
-        )
+        return State(properties.map { (k, v) -> Entry(k, v.value) }.toMutableList())
     }
 
     override fun loadState(toLoad: State) {
-        toLoad.entries?.forEach { p ->
-            properties[p.key]?.let { it.property.set(it.parser(p.value)) }
-        }
+        toLoad.entries.forEach { properties[it.key]?.value = it.value }
     }
 
-    data class State(var entries: Array<Entry>? = arrayOf()) {
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
+    data class State(var entries: MutableList<Entry> = mutableListOf())
 
-            other as State
-
-            if (entries != null) {
-                if (other.entries == null) return false
-                if (!entries!!.contentEquals(other.entries!!)) return false
-            } else if (other.entries != null) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            return entries?.contentHashCode() ?: 0
-        }
-    }
-
-    data class Entry(var key: String = "", var value: String = "")
+    data class Entry(var key : String = "", var value : String = "")
 }

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
@@ -22,7 +22,11 @@ class AutoDarkModeOptions : PersistentStateComponent<AutoDarkModeOptions.State> 
 
     val properties: MutableMap<String, PersistentValueProperty<Any>> = HashMap()
     val containers: List<SettingsContainer> =
-        ServiceUtil.load(SettingsContainer::class.java).filter { it.enabled }.asSequence().toList()
+        ServiceUtil.load(SettingsContainerProvider::class.java)
+            .filter { it.enabled }
+            .map { it.create() }
+            .asSequence()
+            .toList()
 
     init {
         containers

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
@@ -2,7 +2,10 @@ package com.github.weisj.darkmode
 
 import com.github.weisj.darkmode.platform.ServiceUtil
 import com.github.weisj.darkmode.platform.settings.*
-import com.intellij.openapi.components.*
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
 import kotlin.reflect.KMutableProperty0
 
 /**
@@ -19,7 +22,7 @@ class AutoDarkModeOptions : PersistentStateComponent<AutoDarkModeOptions.State> 
 
     val properties: MutableMap<String, PersistentValueProperty<Any>> = HashMap()
     val containers: List<SettingsContainer> =
-        ServiceUtil.load(SettingsContainer::class.java).filter(SettingsContainer::isEnabled).asSequence().toList()
+        ServiceUtil.load(SettingsContainer::class.java).filter { it.enabled }.asSequence().toList()
 
     init {
         containers

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
@@ -61,6 +61,11 @@ class AutoDarkModeOptions : PersistentStateComponent<AutoDarkModeOptions.State> 
         toLoad.entries.forEach {
             properties.getOrPut(it.key, { PersistentValuePropertyStub(it.key, it.value) }).value = it.value
         }
+        settingsLoaded()
+    }
+
+    fun settingsLoaded() {
+        containers.forEach { it.onSettingsLoaded() }
     }
 
     data class State(var entries: MutableList<Entry> = mutableListOf())

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
@@ -1,111 +1,84 @@
 package com.github.weisj.darkmode
 
-import com.intellij.ide.ui.LafManager
-import com.intellij.ide.ui.laf.IntelliJLookAndFeelInfo
-import com.intellij.ide.ui.laf.darcula.DarculaLookAndFeelInfo
+import com.github.weisj.darkmode.platform.ServiceUtil
+import com.github.weisj.darkmode.platform.settings.*
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.RoamingType
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.intellij.openapi.editor.colors.EditorColorsScheme
-import com.intellij.openapi.editor.colors.EditorColorsScheme.DEFAULT_SCHEME_NAME
-import com.intellij.openapi.options.Scheme.EDITABLE_COPY_PREFIX
-import javax.swing.UIManager
+import kotlin.reflect.KMutableProperty0
 
-@State(name = "AutoDarkMode", storages = [Storage("auto-dark-mode.xml", roamingType = RoamingType.PER_OS)])
+/**
+ * The storage for plugin options.
+ *
+ * Settings can be declared by registering a {@link SettingsContainer} service.
+ *
+ * Options can be read and written to by addressing them with their name.
+ * Though accessing fields directly through this class is discouraged. Instead use them through the
+ * {@link SettingsContainer} that provides them.
+ */
+@State(name = "AutoDarkMode2", storages = [Storage("auto-dark-mode2.xml", roamingType = RoamingType.PER_OS)])
 class AutoDarkModeOptions : PersistentStateComponent<AutoDarkModeOptions.State> {
 
-    @Volatile
-    var darkTheme: UIManager.LookAndFeelInfo = DEFAULT_DARK_THEME
+    val properties: MutableMap<String, ValueProperty<Any>> = HashMap()
+    val containers: List<SettingsContainer> = ServiceUtil.load(SettingsContainer::class.java).asSequence().toList()
 
-    @Volatile
-    var lightTheme: UIManager.LookAndFeelInfo = DEFAULT_LIGHT_THEME
+    init {
+        containers.flatMap { it.allProperties() }.forEach { properties[it.property.name] = it }
+    }
 
-    @Volatile
-    var highContrastTheme: UIManager.LookAndFeelInfo = DEFAULT_HIGH_CONTRAST_THEME
+    inline fun <reified T : Any> getProperty(name: String): KMutableProperty0<T>? {
+        return properties[name]?.property?.withType()
+    }
 
-    @Volatile
-    var lightCodeScheme: EditorColorsScheme = DEFAULT_LIGHT_SCHEME
+    inline fun <reified T : Any> getReadProperty(name: String): KMutableProperty0<T>? {
+        return properties[name]?.property?.withOutType()
+    }
 
-    @Volatile
-    var darkCodeScheme: EditorColorsScheme = DEFAULT_DARK_SCHEME
+    inline fun <reified T : Any> getWriteProperty(name: String): KMutableProperty0<T>? {
+        return properties[name]?.property?.withInType()
+    }
 
-    @Volatile
-    var highContrastCodeScheme: EditorColorsScheme = DEFAULT_HIGH_CONTRAST_SCHEME
+    inline fun <reified T : Any> readOrNull(name: String): T? = getReadProperty<T>(name)?.get()
 
-    @Volatile
-    var checkHighContrast: Boolean = DEFAULT_CHECK_HIGH_CONTRAST
+    inline fun <reified T : Any> read(name: String): T = readOrNull(name)!!
+
+    inline fun <reified T : Any> write(name: String, value: T) = getWriteProperty<T>(name)?.set(value)
 
     override fun getState(): State? {
         return State(
-            darkTheme.name, darkTheme.className,
-            lightTheme.name, lightTheme.className,
-            highContrastTheme.name, highContrastTheme.className,
-            lightCodeScheme.name, darkCodeScheme.name,
-            highContrastCodeScheme.name, checkHighContrast
+            properties
+                .mapValues { e -> e.value.property.get().let { e.value.writer(it) } }
+                .map { (k, v) -> Entry(k, v) }
+                .toTypedArray()
         )
     }
 
-    override fun loadState(state: State) {
-        val lafManager = LafManager.getInstance()
-        darkTheme = lafManager.installedLookAndFeels
-            .first { it.name == state.darkName && it.className == state.darkClassName }
-            ?: DEFAULT_DARK_THEME
-        lightTheme = lafManager.installedLookAndFeels
-            .first { it.name == state.lightName && it.className == state.lightClassName }
-            ?: DEFAULT_LIGHT_THEME
-        highContrastTheme = lafManager.installedLookAndFeels
-            .first { it.name == state.highContrastName && it.className == state.highContrastNameClassName }
-            ?: DEFAULT_HIGH_CONTRAST_THEME
-
-        val schemes = EditorColorsManager.getInstance().allSchemes
-        lightCodeScheme = schemes
-            .first { it.name == state.lightSchemeName }
-            ?: DEFAULT_LIGHT_SCHEME
-        darkCodeScheme = schemes
-            .first { it.name == state.darkSchemeName }
-            ?: DEFAULT_DARK_SCHEME
-        highContrastCodeScheme = schemes
-            .first { it.name == state.highContrastSchemeName }
-            ?: DEFAULT_HIGH_CONTRAST_SCHEME
-
-        checkHighContrast = state.checkHighContrast ?: DEFAULT_CHECK_HIGH_CONTRAST
+    override fun loadState(toLoad: State) {
+        toLoad.entries?.forEach { p ->
+            properties[p.key]?.let { it.property.set(it.parser(p.value)) }
+        }
     }
 
-    data class State(
-        var darkName: String? = DEFAULT_DARK_THEME.name,
-        var darkClassName: String? = DEFAULT_DARK_THEME.className,
-        var lightName: String? = DEFAULT_LIGHT_THEME.name,
-        var lightClassName: String? = DEFAULT_LIGHT_THEME.className,
-        var highContrastName: String? = DEFAULT_HIGH_CONTRAST_THEME.name,
-        var highContrastNameClassName: String? = DEFAULT_HIGH_CONTRAST_THEME.className,
-        var lightSchemeName: String? = DEFAULT_LIGHT_SCHEME.name,
-        var darkSchemeName: String? = DEFAULT_DARK_SCHEME.name,
-        var highContrastSchemeName: String? = DEFAULT_HIGH_CONTRAST_SCHEME.name,
-        var checkHighContrast: Boolean? = DEFAULT_CHECK_HIGH_CONTRAST
-    )
+    data class State(var entries: Array<Entry>? = arrayOf()) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
 
-    companion object {
+            other as State
 
-        private fun searchScheme(vararg names: String): EditorColorsScheme = EditorColorsManager.getInstance().run {
-            names.mapNotNull { name ->
-                allSchemes.find { it.name == name } ?: allSchemes.find { it.name == "${EDITABLE_COPY_PREFIX}${name}" }
-            }.firstOrNull() ?: globalScheme
+            if (entries != null) {
+                if (other.entries == null) return false
+                if (!entries!!.contentEquals(other.entries!!)) return false
+            } else if (other.entries != null) return false
+
+            return true
         }
 
-        val DEFAULT_DARK_THEME: UIManager.LookAndFeelInfo = DarculaLookAndFeelInfo()
-        val DEFAULT_LIGHT_THEME: UIManager.LookAndFeelInfo = IntelliJLookAndFeelInfo()
-        val DEFAULT_HIGH_CONTRAST_THEME: UIManager.LookAndFeelInfo = LafManager.getInstance()
-            .installedLookAndFeels.find { it.name.toLowerCase() == "high contrast" }
-            ?: IntelliJLookAndFeelInfo()
-
-        val DEFAULT_LIGHT_SCHEME: EditorColorsScheme = searchScheme("IntelliJ Light", DEFAULT_SCHEME_NAME)
-        val DEFAULT_DARK_SCHEME: EditorColorsScheme = searchScheme("Darcula")
-
-        // Note: The small c in the second contrast is the cyrillic letter `с`.
-        val DEFAULT_HIGH_CONTRAST_SCHEME: EditorColorsScheme = searchScheme("High contrast", "High сontrast")
-
-        const val DEFAULT_CHECK_HIGH_CONTRAST = true
+        override fun hashCode(): Int {
+            return entries?.contentHashCode() ?: 0
+        }
     }
+
+    data class Entry(var key: String = "", var value: String = "")
 }

--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeStartupListener.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeStartupListener.kt
@@ -2,10 +2,15 @@ package com.github.weisj.darkmode
 
 import com.intellij.ide.AppLifecycleListener
 import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.project.Project
 
 class AutoDarkModeStartupListener : AppLifecycleListener {
     override fun appFrameCreated(commandLineArgs: List<String>) {
         ServiceManager.getService(AutoDarkMode::class.java).start()
+    }
+
+    override fun appStarting(projectFromCommandLine: Project?) {
+        IntellijNotificationService.initialize()
     }
 
     override fun appClosing() {

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
@@ -1,9 +1,6 @@
 package com.github.weisj.darkmode
 
-import com.github.weisj.darkmode.platform.settings.ChoiceProperty
-import com.github.weisj.darkmode.platform.settings.SettingsGroup
-import com.github.weisj.darkmode.platform.settings.ValueProperty
-import com.github.weisj.darkmode.platform.settings.withType
+import com.github.weisj.darkmode.platform.settings.*
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
@@ -12,44 +9,43 @@ import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.layout.LayoutBuilder
 import com.intellij.ui.layout.Row
 import com.intellij.ui.layout.panel
+import com.intellij.util.castSafelyTo
 
 class DarkModeConfigurable : BoundConfigurable("Auto Dark Mode") {
 
     override fun createPanel(): DialogPanel {
         val options = ServiceManager.getService(AutoDarkModeOptions::class.java)
 
-        fun Row.addProperty(valueProp: ValueProperty<Any>) {
-            if (valueProp is ChoiceProperty) {
-                val propertyRenderer = SimpleListCellRenderer.create("", valueProp.renderer)
-                row(valueProp.description) {
-                    comboBox(
-                        CollectionComboBoxModel(valueProp.options),
-                        valueProp.property,
-                        renderer = propertyRenderer
-                    )
-                }
-                return
-            }
-            when (valueProp.property.get()) {
-                is Boolean -> row { checkBox(valueProp.description, valueProp.property.withType()!!) }
-                is String -> row(valueProp.description) { textField(valueProp.property.withType()!!) }
-                else -> throw IllegalArgumentException("Not yet implemented")
-            }
-        }
-
-        fun LayoutBuilder.addGroup(group: SettingsGroup) {
-            titledRow(group.name) { group.properties.forEach { addProperty(it) } }
-        }
-
         return panel {
             options.containers.flatMap { container ->
                 container.namedGroups.forEach { addGroup(it) }
-                container.unnamedGroup.properties
-            }.let { unnamed ->
-                titledRow("Other") { unnamed.forEach { addProperty(it) } }
-            }
+                container.unnamedGroup
+            }.let { addGroup(it as SettingsGroup, "Other") }
         }
     }
+
+    private fun Row.addProperty(valueProp: ValueProperty<Any>) {
+        valueProp.castSafelyTo<ChoiceProperty<Any, Any>>()?.let {
+            val propertyRenderer = SimpleListCellRenderer.create("", it.renderer)
+            row(valueProp.description) {
+                comboBox(CollectionComboBoxModel(it.choices), it::choiceValue, renderer = propertyRenderer)
+            }
+            return
+        }
+        val value = valueProp.asPersistent()?.backingValue?:valueProp.value
+        val property = valueProp.asPersistent()?.let { it::backingValue }?: valueProp::value
+        when (value) {
+            is Boolean -> row { checkBox(valueProp.description, property.withType()!!) }
+            is String -> row(valueProp.description) { textField(property.withType()!!) }
+            else -> throw IllegalArgumentException("Not yet implemented")
+        }
+    }
+
+    private fun LayoutBuilder.addGroup(properties: SettingsGroup, name: String) {
+        titledRow(name) { properties.forEach { addProperty(it) } }
+    }
+
+    private fun LayoutBuilder.addGroup(group: NamedSettingsGroup) = addGroup(group, group.name)
 
     override fun apply() {
         super.apply()

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
@@ -11,7 +11,7 @@ import com.intellij.ui.layout.Row
 import com.intellij.ui.layout.panel
 import com.intellij.util.castSafelyTo
 
-class DarkModeConfigurable : BoundConfigurable("Auto Dark Mode") {
+class DarkModeConfigurable : BoundConfigurable(SETTINGS_TITLE) {
 
     override fun createPanel(): DialogPanel {
         val options = ServiceManager.getService(AutoDarkModeOptions::class.java)
@@ -20,7 +20,7 @@ class DarkModeConfigurable : BoundConfigurable("Auto Dark Mode") {
             options.containers.flatMap { container ->
                 container.namedGroups.forEach { addGroup(it) }
                 container.unnamedGroup
-            }.let { addGroup(it as SettingsGroup, "Other") }
+            }.let { addGroup(it as SettingsGroup, UNNAMED_GROUP_TITLE) }
         }
     }
 
@@ -49,5 +49,10 @@ class DarkModeConfigurable : BoundConfigurable("Auto Dark Mode") {
     override fun apply() {
         super.apply()
         ServiceManager.getService(AutoDarkMode::class.java).onSettingsChange()
+    }
+
+    companion object {
+        const val SETTINGS_TITLE = "Auto Dark Mode"
+        const val UNNAMED_GROUP_TITLE = "Other"
     }
 }

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
@@ -32,9 +32,8 @@ class DarkModeConfigurable : BoundConfigurable("Auto Dark Mode") {
             }
             return
         }
-        val value = valueProp.asPersistent()?.backingValue?:valueProp.value
-        val property = valueProp.asPersistent()?.let { it::backingValue }?: valueProp::value
-        when (value) {
+        val property = valueProp.effectiveProperty
+        when (property.get()) {
             is Boolean -> row { checkBox(valueProp.description, property.withType()!!) }
             is String -> row(valueProp.description) { textField(property.withType()!!) }
             else -> throw IllegalArgumentException("Not yet implemented")

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeConfigurable.kt
@@ -1,61 +1,53 @@
 package com.github.weisj.darkmode
 
-import com.intellij.ide.ui.LafManager
+import com.github.weisj.darkmode.platform.settings.ChoiceProperty
+import com.github.weisj.darkmode.platform.settings.SettingsGroup
+import com.github.weisj.darkmode.platform.settings.ValueProperty
+import com.github.weisj.darkmode.platform.settings.withType
 import com.intellij.openapi.components.ServiceManager
-import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.CollectionComboBoxModel
 import com.intellij.ui.SimpleListCellRenderer
-import com.intellij.ui.layout.InnerCell
+import com.intellij.ui.layout.LayoutBuilder
 import com.intellij.ui.layout.Row
 import com.intellij.ui.layout.panel
-import javax.swing.UIManager
-import kotlin.reflect.KMutableProperty0
 
-class DarkModeConfigurable(private val lafManager: LafManager) : BoundConfigurable("Auto Dark Mode") {
+class DarkModeConfigurable : BoundConfigurable("Auto Dark Mode") {
 
     override fun createPanel(): DialogPanel {
         val options = ServiceManager.getService(AutoDarkModeOptions::class.java)
 
-        val lookAndFeels = lafManager.installedLookAndFeels.asList()
-        val lafRenderer = SimpleListCellRenderer.create("") { obj: UIManager.LookAndFeelInfo -> obj.name }
-
-        val schemes = EditorColorsManager.getInstance().allSchemes.asList()
-        val schemeRenderer = SimpleListCellRenderer.create("") { obj: EditorColorsScheme -> obj.displayName }
-
-        fun Row.themeMode(
-            label: String,
-            themeProperty: KMutableProperty0<UIManager.LookAndFeelInfo>,
-            schemeProperty: KMutableProperty0<EditorColorsScheme>
-        ) {
-            row(label) {
-                cell {
-                    comboBox(CollectionComboBoxModel(lookAndFeels), themeProperty, renderer = lafRenderer)
-                    label(" / ")
-                    comboBox(CollectionComboBoxModel(schemes), schemeProperty, renderer = schemeRenderer)
+        fun Row.addProperty(valueProp: ValueProperty<Any>) {
+            if (valueProp is ChoiceProperty) {
+                val propertyRenderer = SimpleListCellRenderer.create("", valueProp.renderer)
+                row(valueProp.description) {
+                    comboBox(
+                        CollectionComboBoxModel(valueProp.options),
+                        valueProp.property,
+                        renderer = propertyRenderer
+                    )
                 }
+                return
             }
+            when (valueProp.property.get()) {
+                is Boolean -> row { checkBox(valueProp.description, valueProp.property.withType()!!) }
+                is String -> row(valueProp.description) { textField(valueProp.property.withType()!!) }
+                else -> throw IllegalArgumentException("Not yet implemented")
+            }
+        }
+
+        fun LayoutBuilder.addGroup(group: SettingsGroup) {
+            titledRow(group.name) { group.properties.forEach { addProperty(it) } }
         }
 
         return panel {
-            titledRow("IDE Theme / Editor Theme") {
-                themeMode("Light Mode:", options::lightTheme, options::lightCodeScheme)
-                themeMode("Dark Mode:", options::darkTheme, options::darkCodeScheme)
-                themeMode("High Contrast Mode:", options::highContrastTheme, options::highContrastCodeScheme)
+            options.containers.flatMap { container ->
+                container.namedGroups.forEach { addGroup(it) }
+                container.unnamedGroup.properties
+            }.let { unnamed ->
+                titledRow("Other") { unnamed.forEach { addProperty(it) } }
             }
-            titledRow("Options") {
-                row {
-                    checkBox("Check for high contrast", options::checkHighContrast)
-                }
-            }
-        }
-    }
-
-    private fun Row.cellRow(title: String = "", init: InnerCell.() -> Unit) {
-        row(title) {
-            cell { this.init() }
         }
     }
 

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -1,5 +1,6 @@
 package com.github.weisj.darkmode
 
+import com.github.weisj.darkmode.platform.Notifications
 import com.github.weisj.darkmode.platform.settings.*
 import com.google.auto.service.AutoService
 import com.intellij.ide.ui.LafManager

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -15,12 +15,20 @@ class GeneralThemeSettingsProvider : SingletonSettingsContainerProvider({ Genera
 
 object GeneralThemeSettings : DefaultSettingsContainer() {
 
+    /**
+     * Default values for the LookAndFeel which are guaranteed to be bundled with any
+     * IntelliJ based product.
+     */
     private enum class DefaultLaf(val info : UIManager.LookAndFeelInfo) {
         DARK(DarculaLookAndFeelInfo()),
         LIGHT(searchLaf("IntelliJ Light") ?: IntelliJLookAndFeelInfo()),
         HIGH_CONTRAST(searchLaf("High Contrast") ?: IntelliJLookAndFeelInfo())
     }
 
+    /**
+     * Default values for the code scheme which are guaranteed to be bundled with any
+     * IntelliJ based product.
+     */
     private enum class DefaultScheme(val scheme: EditorColorsScheme) {
         LIGHT(searchScheme("IntelliJ Light", EditorColorsScheme.DEFAULT_SCHEME_NAME)),
         DARK(searchScheme("Darcula")),

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -1,6 +1,7 @@
 package com.github.weisj.darkmode
 
 import com.github.weisj.darkmode.platform.Notifications
+import com.github.weisj.darkmode.platform.OneTimeAction
 import com.github.weisj.darkmode.platform.settings.*
 import com.google.auto.service.AutoService
 import com.intellij.ide.ui.LafManager
@@ -14,7 +15,7 @@ import javax.swing.UIManager
 @AutoService(SettingsContainerProvider::class)
 class GeneralThemeSettingsProvider : SingletonSettingsContainerProvider({ GeneralThemeSettings })
 
-object GeneralThemeSettings : DefaultSettingsContainer() {
+object GeneralThemeSettings : DefaultSettingsContainer(identifier = "general_settings") {
 
     /**
      * Default values for the LookAndFeel which are guaranteed to be bundled with any

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -48,6 +48,15 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
     var checkHighContrast = DEFAULT_CHECK_HIGH_CONTRAST
 
     init {
+        group {
+            persistentBooleanProperty(
+                description = "Check for high contrast",
+                value = ::checkHighContrast
+            ) {
+                control(withProperty(::highContrastTheme), withProperty(::highContrastCodeScheme))
+            }
+        }
+
         group("IDE Theme") {
             val installedLafs = LafManager.getInstance().installedLookAndFeels.asList()
             val lafRenderer = UIManager.LookAndFeelInfo::getName
@@ -90,15 +99,6 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
                 value = ::highContrastCodeScheme,
                 transformer = schemeTransformer.writeFallback(DefaultScheme.HIGH_CONTRAST.scheme)
             ) { choices = installedSchemes; renderer = schemeRenderer; active = false }
-        }
-
-        group("Other") {
-            persistentBooleanProperty(
-                description = "Check for high contrast",
-                value = ::checkHighContrast
-            ) {
-                control(withProperty(::highContrastTheme), withProperty(::highContrastCodeScheme))
-            }
         }
     }
 

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -14,8 +14,8 @@ import javax.swing.UIManager
  * Workaround for the fact that auto service currently doesn't work with singleton objects.
  * https://github.com/google/auto/issues/785
  */
-@AutoService(SettingsContainer::class)
-class GeneralThemeSettingsProxy : SettingsContainer by GeneralThemeSettings
+@AutoService(SettingsContainerProvider::class)
+class GeneralThemeSettingsProvider : SingletonSettingsContainerProvider({ GeneralThemeSettings })
 
 object GeneralThemeSettings : DefaultSettingsContainer() {
 
@@ -57,7 +57,7 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
                 description = "Light",
                 value = ::lightTheme,
                 transformer = lafTransformer.writeFallback(DefaultLaf.LIGHT.info)
-            ) { choices = installedLafs; renderer = lafRenderer }
+            ) { choices = installedLafs; renderer = lafRenderer; }
             persistentChoiceProperty(
                 description = "Dark",
                 value = ::darkTheme,
@@ -67,7 +67,7 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
                 description = "High Contrast",
                 value = ::highContrastTheme,
                 transformer = lafTransformer.writeFallback(DefaultLaf.HIGH_CONTRAST.info)
-            ) { choices = installedLafs; renderer = lafRenderer }
+            ) { choices = installedLafs; renderer = lafRenderer; }
         }
 
         group("Editor Theme") {
@@ -89,14 +89,16 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
                 description = "High Contrast",
                 value = ::highContrastCodeScheme,
                 transformer = schemeTransformer.writeFallback(DefaultScheme.HIGH_CONTRAST.scheme)
-            ) { choices = installedSchemes; renderer = schemeRenderer }
+            ) { choices = installedSchemes; renderer = schemeRenderer; active = false }
         }
 
-        unnamedGroup {
+        group("Other") {
             persistentBooleanProperty(
                 description = "Check for high contrast",
                 value = ::checkHighContrast
-            )
+            ) {
+                control(withProperty(::highContrastTheme), withProperty(::highContrastCodeScheme))
+            }
         }
     }
 

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -1,0 +1,120 @@
+package com.github.weisj.darkmode
+
+import com.github.weisj.darkmode.platform.settings.*
+import com.google.auto.service.AutoService
+import com.intellij.ide.ui.LafManager
+import com.intellij.ide.ui.laf.IntelliJLookAndFeelInfo
+import com.intellij.ide.ui.laf.darcula.DarculaLookAndFeelInfo
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.options.Scheme
+import javax.swing.UIManager
+
+/**
+ * Workaround for the fact that auto service currently doesn't work with singleton objects.
+ * https://github.com/google/auto/issues/785
+ */
+@AutoService(SettingsContainer::class)
+class GeneralThemeSettingsProxy : SettingsContainer by GeneralThemeSettings
+
+object GeneralThemeSettings : DefaultSettingsContainer() {
+
+    private val DEFAULT_DARK_THEME: UIManager.LookAndFeelInfo =
+        DarculaLookAndFeelInfo()
+    private val DEFAULT_LIGHT_THEME: UIManager.LookAndFeelInfo =
+        searchLaf("IntelliJ Light") ?: IntelliJLookAndFeelInfo()
+    private val DEFAULT_HIGH_CONTRAST_THEME: UIManager.LookAndFeelInfo =
+        searchLaf("High Contrast") ?: IntelliJLookAndFeelInfo()
+
+    private val DEFAULT_LIGHT_SCHEME: EditorColorsScheme =
+        searchScheme("IntelliJ Light", EditorColorsScheme.DEFAULT_SCHEME_NAME)
+    private val DEFAULT_DARK_SCHEME: EditorColorsScheme =
+        searchScheme("Darcula")
+    private val DEFAULT_HIGH_CONTRAST_SCHEME: EditorColorsScheme =
+        // Note: The small c in the second contrast is the cyrillic letter `с`.
+        searchScheme("High contrast", "High сontrast")
+
+    private const val DEFAULT_CHECK_HIGH_CONTRAST = true
+
+    var darkTheme = DEFAULT_DARK_THEME
+    var lightTheme = DEFAULT_LIGHT_THEME
+    var highContrastTheme = DEFAULT_HIGH_CONTRAST_THEME
+
+    var lightCodeScheme = DEFAULT_LIGHT_SCHEME
+    var darkCodeScheme = DEFAULT_DARK_SCHEME
+    var highContrastCodeScheme = DEFAULT_HIGH_CONTRAST_SCHEME
+
+    var checkHighContrast = DEFAULT_CHECK_HIGH_CONTRAST
+
+    init {
+        group("IDE Theme") {
+            val installedLafs = LafManager.getInstance().installedLookAndFeels.asList()
+            val lafRenderer = { obj: UIManager.LookAndFeelInfo -> obj.name }
+
+            choiceProperty("Light", ::lightTheme, parseLaf(DEFAULT_LIGHT_THEME), ::writeLaf) {
+                options = installedLafs; renderer = lafRenderer
+            }
+            choiceProperty("Dark", ::darkTheme, parseLaf(DEFAULT_DARK_THEME), ::writeLaf) {
+                options = installedLafs; renderer = lafRenderer
+            }
+            choiceProperty("High Contrast", ::highContrastTheme, parseLaf(DEFAULT_HIGH_CONTRAST_THEME), ::writeLaf) {
+                options = installedLafs; renderer = lafRenderer
+            }
+        }
+
+        group("Editor Theme") {
+            val installedSchemes = EditorColorsManager.getInstance().allSchemes.asList()
+            val schemeRenderer = { obj: EditorColorsScheme -> obj.displayName }
+            choiceProperty("Light", ::lightCodeScheme, parseScheme(DEFAULT_LIGHT_SCHEME), ::writeScheme) {
+                options = installedSchemes; renderer = schemeRenderer
+            }
+            choiceProperty("Dark", ::darkCodeScheme, parseScheme(DEFAULT_DARK_SCHEME), ::writeScheme) {
+                options = installedSchemes; renderer = schemeRenderer
+            }
+            choiceProperty(
+                "High Contrast", ::highContrastCodeScheme,
+                parseScheme(DEFAULT_HIGH_CONTRAST_SCHEME), ::writeScheme
+            ) {
+                options = installedSchemes; renderer = schemeRenderer
+            }
+        }
+
+        booleanProperty("Check for high contrast", ::checkHighContrast)
+    }
+
+    private fun parseLaf(fallback: UIManager.LookAndFeelInfo): (String) -> UIManager.LookAndFeelInfo {
+        return { s ->
+            s.split(delimiters = *charArrayOf('|'), limit = 2).let {
+                val name = it[0]
+                val className = it[1]
+                searchLaf(name, className) ?: fallback
+            }
+        }
+    }
+
+    private fun writeLaf(info: UIManager.LookAndFeelInfo): String = "${info.name}|${info.className}"
+
+    private fun parseScheme(fallback: EditorColorsScheme): (String) -> EditorColorsScheme {
+        return { s -> getScheme(s) ?: fallback }
+    }
+
+    private fun writeScheme(scheme: EditorColorsScheme): String = scheme.name
+
+    private fun getScheme(name: String): EditorColorsScheme? =
+        EditorColorsManager.getInstance().allSchemes.firstOrNull { it.name == name }
+
+    private fun searchScheme(vararg names: String): EditorColorsScheme {
+        return EditorColorsManager.getInstance().run {
+            names.mapNotNull { name ->
+                allSchemes.firstOrNull { it.name == name }
+                    ?: allSchemes.firstOrNull { it.name == "${Scheme.EDITABLE_COPY_PREFIX}${name}" }
+            }.firstOrNull() ?: globalScheme
+        }
+    }
+
+    private fun searchLaf(name: String, className: String = ""): UIManager.LookAndFeelInfo? {
+        return LafManager.getInstance().installedLookAndFeels.firstOrNull {
+            it.name.toLowerCase() == name.toLowerCase() && (className.isEmpty() || it.className == className)
+        }
+    }
+}

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -17,21 +17,23 @@ import javax.swing.UIManager
 @AutoService(SettingsContainer::class)
 class GeneralThemeSettingsProxy : SettingsContainer by GeneralThemeSettings
 
+typealias LafInfo = UIManager.LookAndFeelInfo
+
 object GeneralThemeSettings : DefaultSettingsContainer() {
 
-    private val DEFAULT_DARK_THEME: UIManager.LookAndFeelInfo =
-        DarculaLookAndFeelInfo()
-    private val DEFAULT_LIGHT_THEME: UIManager.LookAndFeelInfo =
-        searchLaf("IntelliJ Light") ?: IntelliJLookAndFeelInfo()
-    private val DEFAULT_HIGH_CONTRAST_THEME: UIManager.LookAndFeelInfo =
-        searchLaf("High Contrast") ?: IntelliJLookAndFeelInfo()
+    private val DEFAULT_DARK_THEME: LafInfo = DarculaLookAndFeelInfo()
+    private val DEFAULT_LIGHT_THEME: LafInfo = searchLaf("IntelliJ Light") ?: IntelliJLookAndFeelInfo()
+    private val DEFAULT_HIGH_CONTRAST_THEME: LafInfo = searchLaf("High Contrast") ?: IntelliJLookAndFeelInfo()
 
     private val DEFAULT_LIGHT_SCHEME: EditorColorsScheme =
         searchScheme("IntelliJ Light", EditorColorsScheme.DEFAULT_SCHEME_NAME)
     private val DEFAULT_DARK_SCHEME: EditorColorsScheme =
         searchScheme("Darcula")
     private val DEFAULT_HIGH_CONTRAST_SCHEME: EditorColorsScheme =
-        // Note: The small c in the second contrast is the cyrillic letter `с`.
+        /*
+         *  Note: The small c in the second "contrast" is the cyrillic character `с`.
+         * Some versions of IDEA use the incorrect character. We simply search for both version.
+         */
         searchScheme("High contrast", "High сontrast")
 
     private const val DEFAULT_CHECK_HIGH_CONTRAST = true
@@ -49,51 +51,71 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
     init {
         group("IDE Theme") {
             val installedLafs = LafManager.getInstance().installedLookAndFeels.asList()
-            val lafRenderer = { obj: UIManager.LookAndFeelInfo -> obj.name }
+            val lafRenderer = { obj: LafInfo -> obj.name }
+            val createLafTransformer = { fallback: LafInfo -> Transformer(parseLaf(fallback), ::writeLaf) }
 
-            choiceProperty("Light", ::lightTheme, parseLaf(DEFAULT_LIGHT_THEME), ::writeLaf) {
-                options = installedLafs; renderer = lafRenderer
-            }
-            choiceProperty("Dark", ::darkTheme, parseLaf(DEFAULT_DARK_THEME), ::writeLaf) {
-                options = installedLafs; renderer = lafRenderer
-            }
-            choiceProperty("High Contrast", ::highContrastTheme, parseLaf(DEFAULT_HIGH_CONTRAST_THEME), ::writeLaf) {
-                options = installedLafs; renderer = lafRenderer
-            }
+            persistentChoiceProperty(
+                description = "Light",
+                value = ::lightTheme,
+                transformer = createLafTransformer(DEFAULT_LIGHT_THEME)
+            ) { choices = installedLafs; renderer = lafRenderer }
+            persistentChoiceProperty(
+                description = "Dark",
+                value = ::darkTheme,
+                transformer = createLafTransformer(DEFAULT_DARK_THEME)
+            ) { choices = installedLafs; renderer = lafRenderer }
+            persistentChoiceProperty(
+                description = "High Contrast",
+                value = ::highContrastTheme,
+                transformer = createLafTransformer(DEFAULT_HIGH_CONTRAST_THEME)
+            ) { choices = installedLafs; renderer = lafRenderer }
         }
 
         group("Editor Theme") {
             val installedSchemes = EditorColorsManager.getInstance().allSchemes.asList()
             val schemeRenderer = { obj: EditorColorsScheme -> obj.displayName }
-            choiceProperty("Light", ::lightCodeScheme, parseScheme(DEFAULT_LIGHT_SCHEME), ::writeScheme) {
-                options = installedSchemes; renderer = schemeRenderer
-            }
-            choiceProperty("Dark", ::darkCodeScheme, parseScheme(DEFAULT_DARK_SCHEME), ::writeScheme) {
-                options = installedSchemes; renderer = schemeRenderer
-            }
-            choiceProperty(
-                "High Contrast", ::highContrastCodeScheme,
-                parseScheme(DEFAULT_HIGH_CONTRAST_SCHEME), ::writeScheme
-            ) {
-                options = installedSchemes; renderer = schemeRenderer
-            }
+            val createSchemeTransformer =
+                { fallback: EditorColorsScheme -> Transformer(parseScheme(fallback), ::writeScheme) }
+
+            persistentChoiceProperty(
+                description = "Light",
+                value = ::lightCodeScheme,
+                transformer = createSchemeTransformer(DEFAULT_LIGHT_SCHEME)
+            ) { choices = installedSchemes; renderer = schemeRenderer }
+            persistentChoiceProperty(
+                description = "Dark",
+                value = ::darkCodeScheme,
+                transformer = createSchemeTransformer(DEFAULT_DARK_SCHEME)
+            ) { choices = installedSchemes; renderer = schemeRenderer }
+            persistentChoiceProperty(
+                description = "High Contrast",
+                value = ::highContrastCodeScheme,
+                transformer = createSchemeTransformer(DEFAULT_HIGH_CONTRAST_SCHEME)
+            ) { choices = installedSchemes; renderer = schemeRenderer }
         }
 
-        booleanProperty("Check for high contrast", ::checkHighContrast)
-    }
-
-    private fun parseLaf(fallback: UIManager.LookAndFeelInfo): (String) -> UIManager.LookAndFeelInfo {
-        return { s ->
-            s.split(delimiters = *charArrayOf('|'), limit = 2).let {
-                val name = it[0]
-                val className = it[1]
-                searchLaf(name, className) ?: fallback
-            }
+        unnamed {
+            persistentBooleanProperty(
+                description = "Check for high contrast",
+                value = ::checkHighContrast
+            )
         }
     }
 
-    private fun writeLaf(info: UIManager.LookAndFeelInfo): String = "${info.name}|${info.className}"
+    override fun isEnabled(): Boolean = true
 
+    /**
+     * Returns a parser function with the given fallback.
+     */
+    private fun parseLaf(fallback: LafInfo): (String) -> LafInfo {
+        return { s -> s.toPair('|')?.let { searchLaf(it.first, it.second) } ?: fallback }
+    }
+
+    private fun writeLaf(info: LafInfo): String = "${info.className} ${info.name}"
+
+    /**
+     * Returns a parser function with the given fallback.
+     */
     private fun parseScheme(fallback: EditorColorsScheme): (String) -> EditorColorsScheme {
         return { s -> getScheme(s) ?: fallback }
     }
@@ -103,6 +125,14 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
     private fun getScheme(name: String): EditorColorsScheme? =
         EditorColorsManager.getInstance().allSchemes.firstOrNull { it.name == name }
 
+    /**
+     * Search for a given editor scheme.
+     * Schemes may or may not be present in editable form and vice versa.
+     * First try to match the name directly.
+     * If this doesn't succeed try again with the editable version of the name.
+     *
+     * Uses the current scheme as a fallback.
+     */
     private fun searchScheme(vararg names: String): EditorColorsScheme {
         return EditorColorsManager.getInstance().run {
             names.mapNotNull { name ->
@@ -112,7 +142,10 @@ object GeneralThemeSettings : DefaultSettingsContainer() {
         }
     }
 
-    private fun searchLaf(name: String, className: String = ""): UIManager.LookAndFeelInfo? {
+    /**
+     * Search for a given LookAndFeelInfo. The name has to match. If the className isn't empty it also has to match.
+     */
+    private fun searchLaf(name: String, className: String = ""): LafInfo? {
         return LafManager.getInstance().installedLookAndFeels.firstOrNull {
             it.name.toLowerCase() == name.toLowerCase() && (className.isEmpty() || it.className == className)
         }

--- a/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt
@@ -10,10 +10,6 @@ import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.options.Scheme
 import javax.swing.UIManager
 
-/**
- * Workaround for the fact that auto service currently doesn't work with singleton objects.
- * https://github.com/google/auto/issues/785
- */
 @AutoService(SettingsContainerProvider::class)
 class GeneralThemeSettingsProvider : SingletonSettingsContainerProvider({ GeneralThemeSettings })
 

--- a/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
@@ -1,0 +1,37 @@
+package com.github.weisj.darkmode
+
+import com.github.weisj.darkmode.platform.NotificationType
+import com.github.weisj.darkmode.platform.NotificationsService
+import com.google.auto.service.AutoService
+import com.intellij.ide.impl.ProjectUtil
+import com.intellij.notification.NotificationDisplayType
+import com.intellij.notification.NotificationGroup
+
+typealias IntelliJNotificationType = com.intellij.notification.NotificationType
+
+@AutoService(NotificationsService::class)
+class IntellijNotificationService : NotificationsService {
+
+    companion object {
+        private val NOTIFICATION_GROUP = NotificationGroup(
+            displayId = "Auto Dark Mode",
+            displayType = NotificationDisplayType.STICKY_BALLOON,
+            isLogByDefault = true
+        )
+    }
+
+    override fun dispatchNotification(message: String, type: NotificationType) {
+        NOTIFICATION_GROUP.createNotification(
+            title = "Auto Dark Mode",
+            subtitle = null,
+            content = message,
+            type = type.toIntelliJType()
+        ).notify(ProjectUtil.getOpenProjects().getOrNull(0))
+    }
+}
+
+fun NotificationType.toIntelliJType(): IntelliJNotificationType = when (this) {
+    NotificationType.INFO -> IntelliJNotificationType.INFORMATION
+    NotificationType.WARNING -> IntelliJNotificationType.WARNING
+    NotificationType.ERROR -> IntelliJNotificationType.ERROR
+}

--- a/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
@@ -4,29 +4,65 @@ import com.github.weisj.darkmode.platform.NotificationType
 import com.github.weisj.darkmode.platform.NotificationsService
 import com.google.auto.service.AutoService
 import com.intellij.ide.impl.ProjectUtil
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationDisplayType
 import com.intellij.notification.NotificationGroup
+import com.intellij.openapi.options.ShowSettingsUtil
+import java.util.*
 
 typealias IntelliJNotificationType = com.intellij.notification.NotificationType
 
+/**
+ * Workaround for the fact that auto service currently doesn't work with singleton objects.
+ * https://github.com/google/auto/issues/785
+ */
 @AutoService(NotificationsService::class)
-class IntellijNotificationService : NotificationsService {
+class IntellijNotificationServiceProxy : NotificationsService by IntellijNotificationService
 
-    companion object {
-        private val NOTIFICATION_GROUP = NotificationGroup(
-            displayId = "Auto Dark Mode",
-            displayType = NotificationDisplayType.STICKY_BALLOON,
-            isLogByDefault = true
-        )
+object IntellijNotificationService : NotificationsService {
+
+    private val NOTIFICATION_GROUP = NotificationGroup(
+        displayId = "Auto Dark Mode",
+        displayType = NotificationDisplayType.STICKY_BALLOON,
+        isLogByDefault = true
+    )
+
+    /*
+     * Notifications may not be displayed of they are dispatched before the application frame has been
+     * fully created. We queue any incoming messages and dispatch them as soon as the application is ready.
+     */
+    private val messageQueue: Queue<Notification> = LinkedList()
+    private var started = false
+
+    fun initialize() {
+        println("Initialize")
+        started = true
+        val project = ProjectUtil.getOpenProjects().firstOrNull()
+        while (messageQueue.isNotEmpty()) {
+            messageQueue.poll().notify(project)
+        }
     }
 
-    override fun dispatchNotification(message: String, type: NotificationType) {
-        NOTIFICATION_GROUP.createNotification(
+    override fun dispatchNotification(message: String, type: NotificationType, showSettingsLink: Boolean) {
+        val notification = NOTIFICATION_GROUP.createNotification(
             title = "Auto Dark Mode",
             subtitle = null,
             content = message,
             type = type.toIntelliJType()
-        ).notify(ProjectUtil.getOpenProjects().getOrNull(0))
+        ).also {
+            if (showSettingsLink) {
+                it.addAction(NotificationAction.create("View Settings") { _, _ ->
+                    ShowSettingsUtil.getInstance().showSettingsDialog(null, DarkModeConfigurable::class.java)
+                })
+            }
+        }
+        if (!started) {
+            println("Offer")
+            messageQueue.offer(notification)
+        } else {
+            notification.notify(ProjectUtil.getOpenProjects().firstOrNull())
+        }
     }
 }
 

--- a/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
@@ -36,7 +36,6 @@ object IntellijNotificationService : NotificationsService {
     private var started = false
 
     fun initialize() {
-        println("Initialize")
         started = true
         val project = ProjectUtil.getOpenProjects().firstOrNull()
         while (messageQueue.isNotEmpty()) {
@@ -58,7 +57,6 @@ object IntellijNotificationService : NotificationsService {
             }
         }
         if (!started) {
-            println("Offer")
             messageQueue.offer(notification)
         } else {
             notification.notify(ProjectUtil.getOpenProjects().firstOrNull())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,8 +16,8 @@ pluginManagement {
 
 include(
     "dependencies-bom",
-    "plugin",
     "base",
+    "plugin",
     "windows",
     "macos",
     "linux",

--- a/windows/build.gradle.kts
+++ b/windows/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
 library {
     dependencies {
         jvmImplementation(project(":auto-dark-mode-base"))
-        jvmImplementation("com.github.weisj:darklaf-native-utils")
     }
     targetMachines.addAll(machines.windows.x86, machines.windows.x86_64)
     variants.configureEach {

--- a/windows/pre-build-libraries/windows-x86-64/library.md
+++ b/windows/pre-build-libraries/windows-x86-64/library.md
@@ -1,3 +1,3 @@
-If your machine can't build the windows library download the latest
-'auto-dark-mode-windows_x86-64.dll' from the repository and place it in this folder
-renamed as 'auto-dark-mode-windows.dll'.
+If your machine can't build the windows library  and no version could 
+be downloaded from the repository, manually download the latest
+'windows-x86-64' from the repository and place the unpacked library in this folder.

--- a/windows/pre-build-libraries/windows-x86/library.md
+++ b/windows/pre-build-libraries/windows-x86/library.md
@@ -1,3 +1,3 @@
-If your machine can't build the windows library download the latest
-'auto-dark-mode-windows_x86.dll' from the repository and place it in this folder
-renamed as 'auto-dark-mode-windows.dll'.
+If your machine can't build the windows library and no version could 
+be downloaded from the repository, manually download the latest
+'windows-x86.zip' from the repository and place the unpacked library in this folder.

--- a/windows/src/main/java/com/github/weisj/darkmode/platform/windows/WindowsLibrary.java
+++ b/windows/src/main/java/com/github/weisj/darkmode/platform/windows/WindowsLibrary.java
@@ -24,12 +24,11 @@
  */
 package com.github.weisj.darkmode.platform.windows;
 
-import java.util.logging.Logger;
-
-import com.github.weisj.darklaf.platform.AbstractLibrary;
+import com.github.weisj.darkmode.platform.AbstractPluginLibrary;
 import com.github.weisj.darkmode.platform.LibraryUtil;
+import com.github.weisj.darkmode.platform.PluginLogger;
 
-public class WindowsLibrary extends AbstractLibrary {
+public class WindowsLibrary extends AbstractPluginLibrary {
 
     private static final String PROJECT_NAME = "auto-dark-mode-windows";
     private static final String PATH = "/com/github/weisj/darkmode/" + PROJECT_NAME + "/";
@@ -44,7 +43,7 @@ public class WindowsLibrary extends AbstractLibrary {
     }
 
     protected WindowsLibrary() {
-        super(PATH, DLL_NAME, Logger.getLogger(WindowsLibrary.class.getName()));
+        super(PATH, DLL_NAME, PluginLogger.getLogger(WindowsLibrary.class));
     }
 
     @Override


### PR DESCRIPTION
This PR implements a configuration DSL that is agnostic of any implementation details of the IntelliJ Plugin SDK.

The aim is to enable platform implementation modules to specify custom settings that appear in the plugin settings of the IDE (e.g. [on Linux](https://github.com/weisJ/auto-dark-mode/pull/8#issuecomment-658136118)).

Settings are declared by creating a class that extends `DefaultSettingsContainer` (e.g. [`DarkModeThemeSettings`](https://github.com/weisJ/auto-dark-mode/blob/4de8c4b4669fa2e40cc5af886e8e138aa51c84eb/plugin/src/main/java/com/github/weisj/darkmode/DarkModeThemeSettings.kt)) and is registered as a service for `SettingsContainer`.

In the current state it is capable of fully modelling the existing settings. Though changes may need to be done to accommodate more use cases (this needs to be tested after Linux support has been merged).

Note: The new settings format isn't compatible with the old one so any custom changes will need to be redone by the user (not a big problem for such a small plugin). 