### PR TITLE
Enable compatibility with IJ 2020.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ darklaf.version                                           = 2.3.0
 idea.version                                              = [201,)
 ideaPlugin.version                                        = 2020.1
 ideaPlugin.since.version                                   = 201
-ideaPlugin.until.version                                  = 201.*
+ideaPlugin.until.version                                  = 202.*


### PR DESCRIPTION
I just tested locally, by installing the plugin zip manually, on macos.

```
./gradlew build -PgithubAccessToken=$(op get item Github --fields Token.cli-read-only)
```

I chose to keep the actual subversion 2020.1 because the plugin still works with 2010.1.