### PR TITLE
UI freeze mitigations for GTK implementation

### DIFF
--- a/base/src/main/java/com/github/weisj/darkmode/platform/ThemeMonitorImpl.kt
+++ b/base/src/main/java/com/github/weisj/darkmode/platform/ThemeMonitorImpl.kt
@@ -73,8 +73,9 @@ class ThemeMonitorImpl(
     }
 
     private fun stop() {
-        LOGGER.info("Stopped theme monitoring.")
+        LOGGER.info("Stopping theme monitoring.")
         listenerHandle?.let { monitorService.deleteEventHandler(it) }
+        LOGGER.info("Stopped theme monitoring successfully.")
     }
 
     companion object {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure = true
 org.gradle.jvmargs                                        = -noverify
 
 # Version
-auto-dark-mode.version                                    = 1.7.0-2022.1
+auto-dark-mode.version                                    = 1.7.0-2021.1
 
 # Plugins
 com.github.vlsi.vlsi-release-plugins.version              = 1.70


### PR DESCRIPTION
Relates to #57 

I suspect that the GTK application thread wasn't dying got stuck waiting to be woken up. @zliuva could you take a look at this?

Also per the GTK specification calling `run` on `GTK::Application` after `quit` is unspecified behaviour, so instead of caching the instance a new one is created each time.