### PR TITLE
Support IDE 2023.2 EAP

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,6 @@ com.google.devtools.ksp.version                           = 1.7.22-1.0.8
 
 # These versions must always stay in sync with another.
 idea.version                                              = [232,233)
-ideaPlugin.version                                        = LATEST-EAP-SNAPSHOT
+ideaPlugin.version                                        = 2023.2
 ideaPlugin.since.version                                  = 232
 ideaPlugin.until.version                                  = 232.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,11 +23,11 @@ org.gradle.jvmargs                                        = -noverify \
   --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 
 # Version
-auto-dark-mode.version                                    = 1.8.0-2023.1
+auto-dark-mode.version                                    = 1.8.0-2023.2
 
 # Plugins
 com.github.vlsi.vlsi-release-plugins.version              = 1.70
-org.jetbrains.intellij.version                            = 1.13.3
+org.jetbrains.intellij.version                            = 1.14.2
 com.diffplug.spotless.version                             = 6.0.3
 ktlint.version                                            = 0.43.2
 kotlin.version                                            = 1.7.22
@@ -39,3 +39,7 @@ idea.version                                              = [231,232)
 ideaPlugin.version                                        = 2023.1
 ideaPlugin.since.version                                  = 231
 ideaPlugin.until.version                                  = 231.*
+idea.version                                              = [232,233)
+ideaPlugin.version                                        = LATEST-EAP-SNAPSHOT
+ideaPlugin.since.version                                  = 232
+ideaPlugin.until.version                                  = 232.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,10 +35,6 @@ org.ajoberstar.grgit.version                              = 4.1.0
 com.google.devtools.ksp.version                           = 1.7.22-1.0.8
 
 # These versions must always stay in sync with another.
-idea.version                                              = [231,232)
-ideaPlugin.version                                        = 2023.1
-ideaPlugin.since.version                                  = 231
-ideaPlugin.until.version                                  = 231.*
 idea.version                                              = [232,233)
 ideaPlugin.version                                        = LATEST-EAP-SNAPSHOT
 ideaPlugin.since.version                                  = 232


### PR DESCRIPTION
Fixes #70 

Compiled plugin: 
[auto-dark-mode-plugin-1.8.0-2023.2.zip](https://github.com/weisJ/auto-dark-mode/files/12241160/auto-dark-mode-plugin-1.8.0-2023.2.zip)
