### PR TITLE
fix: use instance of service on-demand instead

### DIFF
--- a/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/IntellijNotificationService.kt
@@ -50,9 +50,6 @@ object IntellijNotificationService : NotificationsService {
     private val LOGGER = PluginLogger<IntellijNotificationService>()
     private val ICON = IconLoader.getIcon("/META-INF/pluginIcon.svg", AutoDarkMode::class.java)
 
-    private val NOTIFICATION_GROUP = NotificationGroupManager.getInstance()
-        .getNotificationGroup("com.github.weisj.darkmode")
-
     /*
      * Notifications may not be displayed of they are dispatched before the application frame has been
      * fully created. We queue any incoming messages and dispatch them as soon as the application is ready.
@@ -75,7 +72,8 @@ object IntellijNotificationService : NotificationsService {
     }
 
     override fun dispatchNotification(message: String, type: NotificationType, showSettingsLink: Boolean) {
-        val notification = NOTIFICATION_GROUP.createNotification(
+        val notificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("com.github.weisj.darkmode")
+        val notification = notificationGroup.createNotification(
             title = "Auto Dark Mode",
             content = message,
             type = type.toIntelliJType()


### PR DESCRIPTION
Hi there, Weis.

Recently, I encountered an error when opening the IDE. The error message (attached screenshot and stacktrace) indicates an issue with service initialization within the `IntellijNotificationService` class.
![image](https://github.com/user-attachments/assets/5a2c48b3-84a3-4f06-b6d6-89a9f8b1ffa7)
<details><summary><b>Stacktrace Details</b></summary>

```
java.lang.Throwable: com.github.weisj.darkmode.IntellijNotificationService <clinit> requests com.intellij.notification.NotificationGroupManager instance. Class initialization must not depend on services. Consider using instance of the service on-demand instead.
	        at com.intellij.openapi.diagnostic.Logger.error(Logger.java:376)
	        at com.intellij.serviceContainer.ComponentManagerImplKt.checkOutsideClassInitializer(ComponentManagerImpl.kt:1588)
	        at com.intellij.serviceContainer.ComponentManagerImplKt.getOrCreateInstanceBlocking(ComponentManagerImpl.kt:1557)
	        at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:746)
	        at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:690)
	        at com.intellij.notification.NotificationGroupManager.getInstance(NotificationGroupManager.java:19)
	        at com.github.weisj.darkmode.IntellijNotificationService.<clinit>(IntellijNotificationService.kt:54)
	        at com.github.weisj.darkmode.AutoDarkModeStartupListener.appFrameCreated(AutoDarkModeStartupListener.kt:32)
	        at com.intellij.util.messages.impl.MessageBusImplKt.invokeMethod(MessageBusImpl.kt:722)
	        at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:686)
	        at com.intellij.util.messages.impl.MessageBusImplKt.deliverMessage(MessageBusImpl.kt:445)
	        at com.intellij.util.messages.impl.MessageBusImplKt.pumpWaiting(MessageBusImpl.kt:424)
	        at com.intellij.util.messages.impl.MessageBusImplKt.access$pumpWaiting(MessageBusImpl.kt:1)
	        at com.intellij.util.messages.impl.MessagePublisher.invoke(MessageBusImpl.kt:483)
	        at jdk.proxy2/jdk.proxy2.$Proxy33.appFrameCreated(Unknown Source)
	        at com.intellij.idea.IdeStarter$openProjectIfNeeded$isOpenProjectNeeded$1$1.invokeSuspend(IdeStarter.kt:121)
	        at com.intellij.idea.IdeStarter$openProjectIfNeeded$isOpenProjectNeeded$1$1.invoke(IdeStarter.kt)
	        at com.intellij.idea.IdeStarter$openProjectIfNeeded$isOpenProjectNeeded$1$1.invoke(IdeStarter.kt)
	        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:163)
	        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span(tracer.kt:56)
	        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span$default(tracer.kt:49)
	        at com.intellij.idea.IdeStarter$openProjectIfNeeded$isOpenProjectNeeded$1.invokeSuspend(IdeStarter.kt:119)
	        at com.intellij.idea.IdeStarter$openProjectIfNeeded$isOpenProjectNeeded$1.invoke(IdeStarter.kt)
	        at com.intellij.idea.IdeStarter$openProjectIfNeeded$isOpenProjectNeeded$1.invoke(IdeStarter.kt)
	        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:163)
	        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span(tracer.kt:56)
	        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span$default(tracer.kt:49)
	        at com.intellij.idea.IdeStarter.openProjectIfNeeded$suspendImpl(IdeStarter.kt:118)
	        at com.intellij.idea.IdeStarter.openProjectIfNeeded(IdeStarter.kt)
	        at com.intellij.idea.IdeStarter$start$2$openProjectBlock$1.invokeSuspend(IdeStarter.kt:82)
	        at com.intellij.idea.IdeStarter$start$2$openProjectBlock$1.invoke(IdeStarter.kt)
	        at com.intellij.idea.IdeStarter$start$2$openProjectBlock$1.invoke(IdeStarter.kt)
	        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:163)
	        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	        at com.intellij.idea.IdeStarter$start$2.invokeSuspend(IdeStarter.kt:92)
	        at com.intellij.idea.IdeStarter$start$2.invoke(IdeStarter.kt)
	        at com.intellij.idea.IdeStarter$start$2.invoke(IdeStarter.kt)
	        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	        at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:261)
	        at com.intellij.idea.IdeStarter.start$suspendImpl(IdeStarter.kt:67)
	        at com.intellij.idea.IdeStarter.start(IdeStarter.kt)
	        at com.intellij.platform.ide.bootstrap.ApplicationLoader$executeApplicationStarter$2.invokeSuspend(ApplicationLoader.kt:385)
	        at com.intellij.platform.ide.bootstrap.ApplicationLoader$executeApplicationStarter$2.invoke(ApplicationLoader.kt)
	        at com.intellij.platform.ide.bootstrap.ApplicationLoader$executeApplicationStarter$2.invoke(ApplicationLoader.kt)
	        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:163)
	        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span(tracer.kt:56)
	        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span$default(tracer.kt:49)
	        at com.intellij.platform.ide.bootstrap.ApplicationLoader.executeApplicationStarter(ApplicationLoader.kt:384)
	        at com.intellij.platform.ide.bootstrap.StartupUtil$startApplication$9.invokeSuspend(startup.kt:326)
	        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:608)
	        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:873)
	        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:763)
	        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:750)
```

</details> 

After some investigation, it appears the error is related to a change in IntelliJ behavior introduced in version 2024.2. You can find more details about this change here: https://youtrack.jetbrains.com/issue/IJPL-1045/Forbid-instance-requests-in-clinit.

This commit modifies the `IntellijNotificationService` class to address the aforementioned change. The service is now loaded on-demand within the `dispatchNotification` function instead of during class initialization. This aligns with best practices for service retrieval as outlined in the IntelliJ documentation: https://plugins.jetbrains.com/docs/intellij/plugin-services.html#retrieving-a-service

While I'm confident this change resolves the error, I'd appreciate your expert review of this commit.

I've been a big fan of this project since discovering it. Thank you for your continued development!