### PR TITLE
Fix settings not displaying after first installation

### DIFF
--- a/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
+++ b/plugin/src/main/java/com/github/weisj/darkmode/AutoDarkModeOptions.kt
@@ -63,7 +63,14 @@ class AutoDarkModeOptions : PersistentStateComponent<SettingsState> {
     }
 
     private var storageSettingsVersion: Double = SETTINGS_VERSION
-    var containers: List<SettingsContainer> = listOf()
+    private var _containers: List<SettingsContainer>? = null
+    val containers: List<SettingsContainer>
+        get() {
+            if (_containers == null) {
+                initContainers(SettingsState(emptyList()))
+            }
+            return _containers!!
+        }
     private val properties: MutableMap<PropertyIdentifier, PersistentValueProperty<Any>> by lazy {
         initState(containers, mutableMapOf())
     }
@@ -71,7 +78,7 @@ class AutoDarkModeOptions : PersistentStateComponent<SettingsState> {
     private var loadState = LoadState.INVALID
 
     private fun initContainers(state: SettingsState) {
-        containers = ServiceUtil.load(SettingsContainerProvider::class.java)
+        _containers = ServiceUtil.load(SettingsContainerProvider::class.java)
             .asSequence()
             .filter { it.isEnabled(state) }
             .map { it.create() }
@@ -127,7 +134,7 @@ class AutoDarkModeOptions : PersistentStateComponent<SettingsState> {
             stateAfterLoad = toLoad
             loadState = LoadState.STATE_AFTER_LOAD
         }
-        if (containers.isEmpty()) initContainers(toLoad)
+        if (_containers == null) initContainers(toLoad)
         storageSettingsVersion = toLoad.entries.find {
             it.groupIdentifier == ROOT_GROUP_NAME && it.name == SETTING_VERSION_NAME
         }?.value?.toDouble() ?: SETTINGS_VERSION


### PR DESCRIPTION
Ensure settings containers are initialized when accessed, even if the persistent state hasn't been loaded yet. This fixes the issue where plugin settings appear blank until IDE restart.

The problem occurred because containers were only initialized during loadState(), but the settings UI (DarkModeConfigurable) could access them before state loading completed during dynamic plugin installation.

Changes:
- Convert containers from var to a getter property with lazy initialization
- Initialize containers with empty state if accessed before loadState()
- Ensures settings UI always has access to properly initialized containers

Fixes https://github.com/weisJ/auto-dark-mode/issues/96

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

I've tested this fix by running it with the sandboxed IDE with and without this patch and it does seem to fix it. I've reviewed the code and it looks reasonable to me.