### PR TITLE
local dev - allow running in other ide sandboxes (RustRover etc)

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -13,8 +13,10 @@ plugins {
 val String.v: String get() = rootProject.extra["$this.version"] as String
 val isPublished by props(true)
 val intellijPublishToken: String by props("")
+val intellijType: String by props("IC")
 
 intellij {
+    type.set(intellijType)
     version.set("ideaPlugin".v)
 }
 

--- a/run-rustrover.sh
+++ b/run-rustrover.sh
@@ -1,0 +1,2 @@
+#!/bin/sh -v
+./gradlew :auto-dark-mode-plugin:runIde -PintellijType=RR -x :auto-dark-mode-linux-gtk:compileCpp


### PR DESCRIPTION
- **Allow selecting IDE type via Gradle property**
  Add support for intellijType Gradle property to allow running different
  JetBrains IDEs (RustRover, PyCharm, etc.) instead of always defaulting
  to IntelliJ IDEA Community.
  
  Usage: ./gradlew runIde -PintellijType=RR
  Or add to gradle.properties: intellijType=RR
  
  Defaults to "IC" (IntelliJ IDEA Community) for backwards compatibility.
  
  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
  
  This is just to support local development and shouldn't change the
  plugin behaviour.
  
  Tested and working for me.
  

- **Add sh for launching in rustrover**
  